### PR TITLE
🔧 ci: Add source_folder parameter for coverage path remapping

### DIFF
--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -77,6 +77,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: unit-test
+      source_folder: gearmeshing_ai
 
   integration-test_codecov:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
@@ -88,6 +89,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: integration-test
+      source_folder: gearmeshing_ai
 
   contract-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -99,6 +101,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: contract-test
+      source_folder: gearmeshing_ai
 
   e2e-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -110,6 +113,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: e2e-test
+      source_folder: gearmeshing_ai
 
   all_test:
 #    name: Organize and generate the testing report and upload it to Codecov
@@ -123,3 +127,4 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: all-test
+      source_folder: gearmeshing_ai


### PR DESCRIPTION
## _Target_

Add `source_folder` parameter to coverage organization workflow to ensure correct path remapping for the `gearmeshing_ai/` source folder.

* ### Task summary:

    The reusable workflow `rw_organize_test_cov_reports.yaml` now supports a configurable `source_folder` parameter. This update adds the parameter to all coverage organization jobs to correctly reference the `gearmeshing_ai/` folder instead of the default `src/`.

* ### Task tickets:

    * Task ID: N/A.
    * Relative PRs:
        * Upstream: GitHub-Action_Reusable_Workflows-Python#156

* ### Key point change:

    **Before**:
    ```yaml
    uses: .../rw_organize_test_cov_reports.yaml@master
    with:
      test_type: unit-test
      # Missing source_folder - defaults to 'src/'
    ```
    
    **After**:
    ```yaml
    uses: .../rw_organize_test_cov_reports.yaml@master
    with:
      test_type: unit-test
      source_folder: gearmeshing_ai  # ← Correctly references gearmeshing_ai/
    ```

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD

## _Description_

### Changes Made:

Updated `.github/workflows/rw_build_and_test.yaml`:
- Added `source_folder: gearmeshing_ai` to **unit-test_codecov** job
- Added `source_folder: gearmeshing_ai` to **integration-test_codecov** job
- Added `source_folder: gearmeshing_ai` to **contract-test_codecov** job
- Added `source_folder: gearmeshing_ai` to **e2e-test_codecov** job
- Added `source_folder: gearmeshing_ai` to **all_test** job

### Benefits:

✅ Correct coverage path mapping for `gearmeshing_ai/` folder  
✅ Accurate coverage reports across macOS and Linux runners  
✅ Prevents "No source for code" errors in coverage reports