### PR TITLE
[GMAI-17] ✨ (jira): Load and validate approved work items.

### DIFF
--- a/gearmeshing_ai/adapters/jira_adf.py
+++ b/gearmeshing_ai/adapters/jira_adf.py
@@ -1,0 +1,70 @@
+"""Small, bounded Atlassian Document Format readers used by the Jira adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+_MAX_ADF_DEPTH: Final = 32
+
+
+def _node_text(node: object, *, depth: int = 0) -> str:
+    if depth > _MAX_ADF_DEPTH or not isinstance(node, Mapping):
+        return ""
+    node_type = node.get("type")
+    if node_type == "text":
+        value = node.get("text")
+        return value if isinstance(value, str) else ""
+    if node_type == "hardBreak":
+        return "\n"
+    content = node.get("content")
+    if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+        return ""
+    return "".join(_node_text(child, depth=depth + 1) for child in content)
+
+
+def adf_to_text(document: object) -> str:
+    """Return provider-neutral text without interpreting or extending its meaning."""
+    if not isinstance(document, Mapping):
+        return ""
+    content = document.get("content")
+    if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+        return ""
+    blocks = (_node_text(block).strip() for block in content)
+    return "\n\n".join(block for block in blocks if block)
+
+
+def adf_section_items(document: object, heading: str) -> tuple[str, ...]:
+    """Read list items or paragraphs below a named top-level ADF heading."""
+    if not isinstance(document, Mapping):
+        return ()
+    content = document.get("content")
+    if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+        return ()
+
+    target = heading.casefold().strip()
+    found = False
+    heading_level = 6
+    items: list[str] = []
+    for block in content:
+        if not isinstance(block, Mapping):
+            continue
+        if block.get("type") == "heading":
+            attrs = block.get("attrs")
+            level = attrs.get("level", 6) if isinstance(attrs, Mapping) else 6
+            if found and isinstance(level, int) and level <= heading_level:
+                break
+            if _node_text(block).casefold().strip() == target:
+                found = True
+                heading_level = level if isinstance(level, int) else 6
+            continue
+        if not found:
+            continue
+        if block.get("type") in {"bulletList", "orderedList"}:
+            children = block.get("content")
+            if isinstance(children, Sequence) and not isinstance(children, (str, bytes)):
+                items.extend(text for child in children if (text := _node_text(child).strip()))
+        elif block.get("type") == "paragraph":
+            if text := _node_text(block).strip():
+                items.append(text)
+    return tuple(items)

--- a/gearmeshing_ai/adapters/jira_errors.py
+++ b/gearmeshing_ai/adapters/jira_errors.py
@@ -1,0 +1,39 @@
+"""Typed failures exposed by the Jira work-management adapter."""
+
+from __future__ import annotations
+
+from gearmeshing_ai.application.ports.work_management import ReadinessResult
+
+
+class JiraAdapterError(RuntimeError):
+    """Base class for Jira adapter failures safe to surface to callers."""
+
+
+class JiraAuthenticationError(JiraAdapterError):
+    """Raised when Jira rejects the configured authentication."""
+
+
+class JiraAuthorizationError(JiraAdapterError):
+    """Raised when the authenticated user cannot perform an operation."""
+
+
+class JiraIssueNotFoundError(JiraAdapterError):
+    """Raised when Jira cannot find the requested issue."""
+
+
+class JiraRateLimitError(JiraAdapterError):
+    """Raised when bounded rate-limit retries are exhausted."""
+
+
+class JiraTransportError(JiraAdapterError):
+    """Raised when Jira cannot be reached or returns an unsafe response."""
+
+
+class JiraIssueValidationError(JiraAdapterError):
+    """Raised before normalization when a Jira issue is not executable."""
+
+    def __init__(self, external_key: str, readiness: ReadinessResult) -> None:
+        details = "; ".join(problem.message for problem in readiness.problems)
+        super().__init__(f"Jira issue {external_key!r} is not ready: {details}")
+        self.external_key = external_key
+        self.readiness = readiness

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -179,9 +179,7 @@ class JiraWorkManagementProvider(WorkManagementProvider):
 
     async def _retrieve_work_item(self, external_key: str) -> WorkItem:
         issue_key = self._issue_key(external_key)
-        fields = ",".join(
-            ("summary", "description", "issuetype", "labels", self._config.repository_url_field)
-        )
+        fields = ",".join(("summary", "description", "issuetype", "labels", self._config.repository_url_field))
         payload = await self._request_json("GET", f"/rest/api/3/issue/{issue_key}?fields={fields}")
         readiness = self._payload_readiness(payload)
         if not readiness.ready:

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -181,9 +181,11 @@ class JiraWorkManagementProvider(WorkManagementProvider):
         retry_after = response.headers.get("Retry-After", "")
         try:
             requested = float(retry_after)
-        except ValueError:
+            if not isfinite(requested) or requested < 0:
+                raise ValueError
+        except (OverflowError, ValueError):
             requested = float(2**attempt)
-        return min(max(requested, 0.0), self._config.max_retry_delay_seconds)
+        return min(requested, self._config.max_retry_delay_seconds)
 
     @staticmethod
     def _raise_for_status(response: httpx.Response) -> None:

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -66,7 +66,12 @@ class JiraWorkManagementConfig:
             raise ValueError(message) from error
         object.__setattr__(self, "supported_issue_types", supported_issue_types)
 
-        parsed = urlsplit(self.site_url)
+        try:
+            parsed = urlsplit(self.site_url)
+            _ = parsed.port
+        except (TypeError, ValueError) as error:
+            message = "site_url must contain a valid host and port."
+            raise ValueError(message) from error
         if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
             message = "site_url must be an HTTPS URL without credentials."
             raise ValueError(message)

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -1,0 +1,309 @@
+"""Jira Cloud implementation of the normalized work-management contract."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from json import JSONDecodeError
+from typing import Any, Final
+from urllib.parse import urlsplit
+
+import httpx
+
+from gearmeshing_ai.adapters.jira_adf import adf_section_items, adf_to_text
+from gearmeshing_ai.adapters.jira_errors import (
+    JiraAuthenticationError,
+    JiraAuthorizationError,
+    JiraIssueNotFoundError,
+    JiraIssueValidationError,
+    JiraRateLimitError,
+    JiraTransportError,
+)
+from gearmeshing_ai.application.ports.work_management import (
+    BlockerUpdate,
+    ProgressUpdate,
+    ProviderCapabilities,
+    ProviderCapability,
+    ReadinessProblem,
+    ReadinessResult,
+    UpdateKind,
+    UpdateReceipt,
+    WorkItem,
+    WorkManagementProvider,
+    WorkRepository,
+)
+
+_ISSUE_KEY_PATTERN: Final = re.compile(r"^[A-Z][A-Z0-9_]{1,9}-[1-9][0-9]*$")
+_FIELD_ID_PATTERN: Final = re.compile(r"^(?:customfield_[1-9][0-9]*|[a-z][a-zA-Z0-9_]*)$")
+_SUCCESS_STATUSES: Final = frozenset({200, 201})
+
+
+@dataclass(frozen=True, slots=True)
+class JiraWorkManagementConfig:
+    """Non-secret Jira mapping required to interpret an approved work item."""
+
+    site_url: str
+    repository_url_field: str
+    repository_default_branch: str = "main"
+    ready_label: str = "spec-ready"
+    supported_issue_types: frozenset[str] = field(default_factory=lambda: frozenset({"Story", "Task"}))
+    request_timeout_seconds: float = 10.0
+    max_attempts: int = 3
+    max_retry_delay_seconds: float = 2.0
+    max_response_bytes: int = 1_000_000
+
+    def __post_init__(self) -> None:
+        parsed = urlsplit(self.site_url)
+        if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+            message = "site_url must be an HTTPS URL without credentials."
+            raise ValueError(message)
+        if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+            message = "site_url must not contain a path, query, or fragment."
+            raise ValueError(message)
+        if not _FIELD_ID_PATTERN.fullmatch(self.repository_url_field):
+            message = "repository_url_field must be an explicit Jira field ID."
+            raise ValueError(message)
+        if not self.ready_label.strip() or any(character.isspace() for character in self.ready_label):
+            message = "ready_label must be a non-empty Jira label."
+            raise ValueError(message)
+        if not self.supported_issue_types or any(not value.strip() for value in self.supported_issue_types):
+            message = "supported_issue_types must not be empty."
+            raise ValueError(message)
+        if self.request_timeout_seconds <= 0 or not 1 <= self.max_attempts <= 5:
+            message = "HTTP bounds must be positive and max_attempts must not exceed five."
+            raise ValueError(message)
+        if self.max_retry_delay_seconds < 0 or self.max_response_bytes <= 0:
+            message = "HTTP response bounds must be positive."
+            raise ValueError(message)
+        WorkRepository("https://validation.invalid/repository", self.repository_default_branch)
+
+
+class JiraWorkManagementProvider(WorkManagementProvider):
+    """Load spec-ready Jira issues and publish their readiness diagnostics."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        config: JiraWorkManagementConfig,
+        *,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._client = client
+        self._config = config
+        self._sleep = sleep
+        self._capabilities = ProviderCapabilities(
+            provider_name="jira-cloud",
+            supported=frozenset(
+                {
+                    ProviderCapability.RETRIEVE_WORK_ITEM,
+                    ProviderCapability.VALIDATE_READINESS,
+                    ProviderCapability.PUBLISH_PROGRESS,
+                    ProviderCapability.PUBLISH_BLOCKER,
+                }
+            ),
+        )
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return self._capabilities
+
+    async def _request_json(self, method: str, path: str, *, json: object | None = None) -> Mapping[str, Any]:
+        url = f"{self._config.site_url.rstrip('/')}{path}"
+        for attempt in range(self._config.max_attempts):
+            try:
+                response = await self._client.request(
+                    method,
+                    url,
+                    json=json,
+                    timeout=self._config.request_timeout_seconds,
+                    follow_redirects=False,
+                )
+            except (httpx.TimeoutException, httpx.RequestError) as error:
+                message = "Jira could not be reached within the configured request bound."
+                raise JiraTransportError(message) from error
+
+            if response.status_code == 429 and attempt + 1 < self._config.max_attempts:
+                await self._sleep(self._retry_delay(response, attempt))
+                continue
+            self._raise_for_status(response)
+            if len(response.content) > self._config.max_response_bytes:
+                message = "Jira returned a response larger than the configured bound."
+                raise JiraTransportError(message)
+            try:
+                payload = response.json()
+            except (JSONDecodeError, ValueError) as error:
+                message = "Jira returned an invalid JSON response."
+                raise JiraTransportError(message) from error
+            if not isinstance(payload, Mapping):
+                message = "Jira returned an unexpected JSON response shape."
+                raise JiraTransportError(message)
+            return payload
+        message = "Jira rate limiting exceeded the configured retry bound."
+        raise JiraRateLimitError(message)
+
+    def _retry_delay(self, response: httpx.Response, attempt: int) -> float:
+        retry_after = response.headers.get("Retry-After", "")
+        try:
+            requested = float(retry_after)
+        except ValueError:
+            requested = float(2**attempt)
+        return min(max(requested, 0.0), self._config.max_retry_delay_seconds)
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.status_code in _SUCCESS_STATUSES:
+            return
+        if response.status_code == 401:
+            message = "Jira authentication failed; verify the configured credentials."
+            raise JiraAuthenticationError(message)
+        if response.status_code == 403:
+            message = "The Jira user is not permitted to access this work item."
+            raise JiraAuthorizationError(message)
+        if response.status_code == 404:
+            message = "The requested Jira issue was not found or is not visible."
+            raise JiraIssueNotFoundError(message)
+        if response.status_code == 429:
+            message = "Jira rate limiting exceeded the configured retry bound."
+            raise JiraRateLimitError(message)
+        message = f"Jira returned HTTP {response.status_code}."
+        raise JiraTransportError(message)
+
+    @staticmethod
+    def _issue_key(external_key: str) -> str:
+        if not _ISSUE_KEY_PATTERN.fullmatch(external_key):
+            message = "external_key must be a canonical Jira issue key."
+            raise ValueError(message)
+        return external_key
+
+    async def _retrieve_work_item(self, external_key: str) -> WorkItem:
+        issue_key = self._issue_key(external_key)
+        fields = ",".join(
+            ("summary", "description", "issuetype", "labels", self._config.repository_url_field)
+        )
+        payload = await self._request_json("GET", f"/rest/api/3/issue/{issue_key}?fields={fields}")
+        readiness = self._payload_readiness(payload)
+        if not readiness.ready:
+            raise JiraIssueValidationError(issue_key, readiness)
+
+        issue_fields = payload["fields"]
+        assert isinstance(issue_fields, Mapping)
+        issue_type = issue_fields["issuetype"]
+        assert isinstance(issue_type, Mapping)
+        labels = issue_fields["labels"]
+        assert isinstance(labels, Sequence)
+        return WorkItem(
+            external_key=issue_key,
+            title=issue_fields["summary"],
+            specification=adf_to_text(issue_fields["description"]),
+            acceptance_criteria=adf_section_items(issue_fields["description"], "Acceptance Criteria"),
+            repository=WorkRepository(
+                url=issue_fields[self._config.repository_url_field],
+                default_branch=self._config.repository_default_branch,
+            ),
+            metadata={"labels": tuple(labels), "work_item_type": issue_type["name"]},
+        )
+
+    def _payload_readiness(self, payload: Mapping[str, Any]) -> ReadinessResult:
+        fields = payload.get("fields")
+        if not isinstance(fields, Mapping):
+            return self._blocked("invalid_payload", "Jira did not return a fields object.")
+
+        problems: list[ReadinessProblem] = []
+        issue_type = fields.get("issuetype")
+        issue_type_name = issue_type.get("name") if isinstance(issue_type, Mapping) else None
+        if not isinstance(issue_type_name, str) or issue_type_name not in self._config.supported_issue_types:
+            problems.append(
+                ReadinessProblem(
+                    "unsupported_issue_type",
+                    "Use one of these supported Jira issue types: "
+                    f"{', '.join(sorted(self._config.supported_issue_types))}.",
+                )
+            )
+        if not isinstance(fields.get("summary"), str) or not fields["summary"].strip():
+            problems.append(ReadinessProblem("missing_summary", "Add a Jira summary before marking the issue ready."))
+        description = fields.get("description")
+        if not adf_to_text(description):
+            problems.append(
+                ReadinessProblem("missing_description", "Add a Jira description before marking the issue ready.")
+            )
+        if not adf_section_items(description, "Acceptance Criteria"):
+            problems.append(
+                ReadinessProblem(
+                    "missing_acceptance_criteria",
+                    "Add an Acceptance Criteria section with at least one item; no criteria will be inferred.",
+                )
+            )
+        repository_url = fields.get(self._config.repository_url_field)
+        try:
+            if not isinstance(repository_url, str):
+                raise ValueError
+            WorkRepository(repository_url, self._config.repository_default_branch)
+        except ValueError:
+            problems.append(
+                ReadinessProblem(
+                    "missing_repository",
+                    f"Set Jira field {self._config.repository_url_field!r} to a credential-free HTTPS repository URL.",
+                )
+            )
+        labels = fields.get("labels")
+        if (
+            not isinstance(labels, Sequence)
+            or isinstance(labels, (str, bytes))
+            or self._config.ready_label not in labels
+        ):
+            problems.append(
+                ReadinessProblem(
+                    "not_spec_ready",
+                    f"Add the {self._config.ready_label!r} label after the specification is approved.",
+                )
+            )
+        return ReadinessResult(ready=not problems, problems=tuple(problems))
+
+    @staticmethod
+    def _blocked(code: str, message: str) -> ReadinessResult:
+        return ReadinessResult(ready=False, problems=(ReadinessProblem(code, message),))
+
+    async def _validate_readiness(self, work_item: WorkItem) -> ReadinessResult:
+        labels = work_item.metadata.get("labels", ())
+        issue_type = work_item.metadata.get("work_item_type")
+        problems: list[ReadinessProblem] = []
+        if issue_type not in self._config.supported_issue_types:
+            problems.append(ReadinessProblem("unsupported_issue_type", "The normalized work item type is unsupported."))
+        if not isinstance(labels, tuple) or self._config.ready_label not in labels:
+            problems.append(
+                ReadinessProblem("not_spec_ready", "The normalized work item is not approved for execution.")
+            )
+        return ReadinessResult(ready=not problems, problems=tuple(problems))
+
+    async def publish_readiness(self, external_key: str, readiness: ReadinessResult) -> UpdateReceipt:
+        """Publish a validation outcome through guarded provider operations."""
+        if readiness.ready:
+            return await self.publish_progress(external_key, ProgressUpdate("Specification validation passed."))
+        message = "Specification validation blocked:\n" + "\n".join(
+            f"- [{problem.code}] {problem.message}" for problem in readiness.problems
+        )
+        return await self.publish_blocker(external_key, BlockerUpdate(message))
+
+    async def _publish_progress(self, external_key: str, update: ProgressUpdate) -> UpdateReceipt:
+        return await self._publish_comment(external_key, update.message, UpdateKind.PROGRESS)
+
+    async def _publish_blocker(self, external_key: str, update: BlockerUpdate) -> UpdateReceipt:
+        return await self._publish_comment(external_key, update.reason, UpdateKind.BLOCKER)
+
+    async def _publish_comment(self, external_key: str, message: str, kind: UpdateKind) -> UpdateReceipt:
+        issue_key = self._issue_key(external_key)
+        body = {
+            "body": {
+                "type": "doc",
+                "version": 1,
+                "content": [{"type": "paragraph", "content": [{"type": "text", "text": message}]}],
+            }
+        }
+        payload = await self._request_json("POST", f"/rest/api/3/issue/{issue_key}/comment", json=body)
+        reference = payload.get("id")
+        if not isinstance(reference, str) or not reference:
+            message = "Jira did not return a comment identifier."
+            raise JiraTransportError(message)
+        return UpdateReceipt(external_key=issue_key, kind=kind, provider_reference=reference)

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from json import JSONDecodeError
+from math import isfinite
 from typing import Any, Final
 from urllib.parse import urlsplit
 
@@ -80,11 +81,35 @@ class JiraWorkManagementConfig:
         ):
             message = "supported_issue_types must contain non-empty strings."
             raise ValueError(message)
-        if self.request_timeout_seconds <= 0 or not 1 <= self.max_attempts <= 5:
-            message = "HTTP bounds must be positive and max_attempts must not exceed five."
+        if (
+            isinstance(self.request_timeout_seconds, bool)
+            or not isinstance(self.request_timeout_seconds, (int, float))
+            or not isfinite(self.request_timeout_seconds)
+            or self.request_timeout_seconds <= 0
+        ):
+            message = "request_timeout_seconds must be a positive finite number."
             raise ValueError(message)
-        if self.max_retry_delay_seconds < 0 or self.max_response_bytes <= 0:
-            message = "HTTP response bounds must be positive."
+        if (
+            isinstance(self.max_attempts, bool)
+            or not isinstance(self.max_attempts, int)
+            or not 1 <= self.max_attempts <= 5
+        ):
+            message = "max_attempts must be an integer between one and five."
+            raise ValueError(message)
+        if (
+            isinstance(self.max_retry_delay_seconds, bool)
+            or not isinstance(self.max_retry_delay_seconds, (int, float))
+            or not isfinite(self.max_retry_delay_seconds)
+            or self.max_retry_delay_seconds < 0
+        ):
+            message = "max_retry_delay_seconds must be a non-negative finite number."
+            raise ValueError(message)
+        if (
+            isinstance(self.max_response_bytes, bool)
+            or not isinstance(self.max_response_bytes, int)
+            or self.max_response_bytes <= 0
+        ):
+            message = "max_response_bytes must be a positive integer."
             raise ValueError(message)
         WorkRepository("https://validation.invalid/repository", self.repository_default_branch)
 

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -56,6 +56,9 @@ class JiraWorkManagementConfig:
     max_response_bytes: int = 1_000_000
 
     def __post_init__(self) -> None:
+        if isinstance(self.supported_issue_types, (str, bytes)):
+            message = "supported_issue_types must be a collection, not text."
+            raise ValueError(message)
         try:
             supported_issue_types = frozenset(self.supported_issue_types)
         except TypeError as error:

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -6,7 +6,7 @@ import asyncio
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from json import JSONDecodeError
+from json import JSONDecodeError, loads
 from math import isfinite
 from typing import Any, Final
 from urllib.parse import urlsplit
@@ -149,34 +149,41 @@ class JiraWorkManagementProvider(WorkManagementProvider):
     async def _request_json(self, method: str, path: str, *, json: object | None = None) -> Mapping[str, Any]:
         url = f"{self._config.site_url.rstrip('/')}{path}"
         for attempt in range(self._config.max_attempts):
+            retry_delay: float | None = None
             try:
-                response = await self._client.request(
+                async with self._client.stream(
                     method,
                     url,
                     json=json,
                     timeout=self._config.request_timeout_seconds,
                     follow_redirects=False,
-                )
+                ) as response:
+                    if response.status_code == 429 and attempt + 1 < self._config.max_attempts:
+                        retry_delay = self._retry_delay(response, attempt)
+                    else:
+                        self._raise_for_status(response)
+                        content = bytearray()
+                        async for chunk in response.aiter_bytes():
+                            if len(content) + len(chunk) > self._config.max_response_bytes:
+                                message = "Jira returned a response larger than the configured bound."
+                                raise JiraTransportError(message)
+                            content.extend(chunk)
+                        try:
+                            payload = loads(content)
+                        except (JSONDecodeError, UnicodeDecodeError, ValueError) as error:
+                            message = "Jira returned an invalid JSON response."
+                            raise JiraTransportError(message) from error
+                        if not isinstance(payload, Mapping):
+                            message = "Jira returned an unexpected JSON response shape."
+                            raise JiraTransportError(message)
+                        return payload
             except (httpx.TimeoutException, httpx.RequestError) as error:
                 message = "Jira could not be reached within the configured request bound."
                 raise JiraTransportError(message) from error
 
-            if response.status_code == 429 and attempt + 1 < self._config.max_attempts:
-                await self._sleep(self._retry_delay(response, attempt))
+            if retry_delay is not None:
+                await self._sleep(retry_delay)
                 continue
-            self._raise_for_status(response)
-            if len(response.content) > self._config.max_response_bytes:
-                message = "Jira returned a response larger than the configured bound."
-                raise JiraTransportError(message)
-            try:
-                payload = response.json()
-            except (JSONDecodeError, ValueError) as error:
-                message = "Jira returned an invalid JSON response."
-                raise JiraTransportError(message) from error
-            if not isinstance(payload, Mapping):
-                message = "Jira returned an unexpected JSON response shape."
-                raise JiraTransportError(message)
-            return payload
         message = "Jira rate limiting exceeded the configured retry bound."
         raise JiraRateLimitError(message)
 

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -182,7 +182,7 @@ class JiraWorkManagementProvider(WorkManagementProvider):
                             message = "Jira returned an unexpected JSON response shape."
                             raise JiraTransportError(message)
                         return payload
-            except (httpx.TimeoutException, httpx.RequestError) as error:
+            except (httpx.InvalidURL, httpx.TimeoutException, httpx.RequestError) as error:
                 message = "Jira could not be reached within the configured request bound."
                 raise JiraTransportError(message) from error
 

--- a/gearmeshing_ai/adapters/jira_work_management.py
+++ b/gearmeshing_ai/adapters/jira_work_management.py
@@ -55,6 +55,13 @@ class JiraWorkManagementConfig:
     max_response_bytes: int = 1_000_000
 
     def __post_init__(self) -> None:
+        try:
+            supported_issue_types = frozenset(self.supported_issue_types)
+        except TypeError as error:
+            message = "supported_issue_types must be an iterable of strings."
+            raise ValueError(message) from error
+        object.__setattr__(self, "supported_issue_types", supported_issue_types)
+
         parsed = urlsplit(self.site_url)
         if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
             message = "site_url must be an HTTPS URL without credentials."
@@ -68,8 +75,10 @@ class JiraWorkManagementConfig:
         if not self.ready_label.strip() or any(character.isspace() for character in self.ready_label):
             message = "ready_label must be a non-empty Jira label."
             raise ValueError(message)
-        if not self.supported_issue_types or any(not value.strip() for value in self.supported_issue_types):
-            message = "supported_issue_types must not be empty."
+        if not self.supported_issue_types or any(
+            not isinstance(value, str) or not value.strip() for value in self.supported_issue_types
+        ):
+            message = "supported_issue_types must contain non-empty strings."
             raise ValueError(message)
         if self.request_timeout_seconds <= 0 or not 1 <= self.max_attempts <= 5:
             message = "HTTP bounds must be positive and max_attempts must not exceed five."

--- a/gearmeshing_ai/application/ports/work_management.py
+++ b/gearmeshing_ai/application/ports/work_management.py
@@ -1,0 +1,343 @@
+"""Provider-neutral contract for work-management integrations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Final, final
+from urllib.parse import urlsplit
+
+
+_MAX_IDENTIFIER_LENGTH: Final = 255
+_MAX_TEXT_LENGTH: Final = 100_000
+_SENSITIVE_METADATA_KEYS: Final = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "api_token",
+        "authorization",
+        "client_secret",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+    }
+)
+
+
+class WorkManagementContractError(ValueError):
+    """Base error raised before unsafe data reaches a provider adapter."""
+
+
+class UnsupportedProviderFeature(WorkManagementContractError):
+    """Raised when an adapter does not declare a requested capability."""
+
+    def __init__(self, provider_name: str, capability: ProviderCapability) -> None:
+        super().__init__(f"Provider {provider_name!r} does not support {capability.value!r}.")
+        self.provider_name = provider_name
+        self.capability = capability
+
+
+class ProviderCapability(str, Enum):
+    """Operations that a work-management provider may support."""
+
+    RETRIEVE_WORK_ITEM = "retrieve_work_item"
+    VALIDATE_READINESS = "validate_readiness"
+    PUBLISH_PROGRESS = "publish_progress"
+    PUBLISH_BLOCKER = "publish_blocker"
+    PUBLISH_COMPLETION = "publish_completion"
+    PUBLISH_ARTIFACT = "publish_artifact"
+
+
+class UpdateKind(str, Enum):
+    """Provider-neutral update categories."""
+
+    PROGRESS = "progress"
+    BLOCKER = "blocker"
+    COMPLETION = "completion"
+    ARTIFACT = "artifact"
+
+
+def _normalize_text(value: str, field_name: str, *, max_length: int = _MAX_TEXT_LENGTH) -> str:
+    if not isinstance(value, str):
+        raise WorkManagementContractError(f"{field_name} must be a string.")
+    normalized = value.strip()
+    if not normalized:
+        raise WorkManagementContractError(f"{field_name} must not be empty.")
+    if len(normalized) > max_length:
+        raise WorkManagementContractError(f"{field_name} exceeds its maximum length.")
+    if any(ord(character) < 32 and character not in "\n\t" for character in normalized):
+        raise WorkManagementContractError(f"{field_name} contains control characters.")
+    return normalized
+
+
+def _normalize_identifier(value: str, field_name: str = "external_key") -> str:
+    normalized = _normalize_text(value, field_name, max_length=_MAX_IDENTIFIER_LENGTH)
+    if any(character.isspace() for character in normalized):
+        raise WorkManagementContractError(f"{field_name} must not contain whitespace.")
+    return normalized
+
+
+def _normalize_url(value: str, field_name: str, *, schemes: frozenset[str]) -> str:
+    normalized = _normalize_text(value, field_name, max_length=2_048)
+    parsed = urlsplit(normalized)
+    if parsed.scheme.lower() not in schemes:
+        raise WorkManagementContractError(f"{field_name} uses an unsupported URL scheme.")
+    if parsed.scheme.lower() == "https" and not parsed.hostname:
+        raise WorkManagementContractError(f"{field_name} must include a host.")
+    if parsed.username is not None or parsed.password is not None:
+        raise WorkManagementContractError(f"{field_name} must not contain credentials.")
+    return normalized
+
+
+def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise WorkManagementContractError(f"{path} keys must be strings.")
+            normalized_key = _normalize_text(key, f"{path} key", max_length=128)
+            if normalized_key.lower() in _SENSITIVE_METADATA_KEYS:
+                raise WorkManagementContractError(f"{path} contains a sensitive key: {normalized_key!r}.")
+            frozen[normalized_key] = _freeze_metadata(item, path=f"{path}.{normalized_key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_metadata(item, path=path) for item in value)
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    raise WorkManagementContractError(f"{path} contains an unsupported value type.")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapabilities:
+    """Identity and supported operations declared by an adapter."""
+
+    provider_name: str
+    supported: frozenset[ProviderCapability]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provider_name", _normalize_identifier(self.provider_name, "provider_name"))
+        object.__setattr__(self, "supported", frozenset(self.supported))
+        if not all(isinstance(capability, ProviderCapability) for capability in self.supported):
+            raise WorkManagementContractError("supported must contain ProviderCapability values.")
+
+    def require(self, capability: ProviderCapability) -> None:
+        """Raise explicitly when the provider does not support an operation."""
+
+        if capability not in self.supported:
+            raise UnsupportedProviderFeature(self.provider_name, capability)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkRepository:
+    """Normalized repository coordinates for an approved work item."""
+
+    url: str
+    default_branch: str = "main"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "url", _normalize_url(self.url, "repository.url", schemes=frozenset({"https"})))
+        object.__setattr__(
+            self,
+            "default_branch",
+            _normalize_identifier(self.default_branch, "repository.default_branch"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkItem:
+    """Approved work specification independent of any provider payload."""
+
+    external_key: str
+    title: str
+    specification: str
+    acceptance_criteria: tuple[str, ...]
+    repository: WorkRepository
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "external_key", _normalize_identifier(self.external_key))
+        object.__setattr__(self, "title", _normalize_text(self.title, "title", max_length=1_000))
+        object.__setattr__(self, "specification", _normalize_text(self.specification, "specification"))
+        criteria = tuple(
+            _normalize_text(criterion, "acceptance_criteria item", max_length=10_000)
+            for criterion in self.acceptance_criteria
+        )
+        if not criteria:
+            raise WorkManagementContractError("acceptance_criteria must not be empty.")
+        object.__setattr__(self, "acceptance_criteria", criteria)
+        if not isinstance(self.repository, WorkRepository):
+            raise WorkManagementContractError("repository must be a WorkRepository.")
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessProblem:
+    """A provider-neutral reason that work cannot start."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "code", _normalize_identifier(self.code, "readiness.code"))
+        object.__setattr__(self, "message", _normalize_text(self.message, "readiness.message", max_length=10_000))
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessResult:
+    """Result of validating whether an approved work item is executable."""
+
+    ready: bool
+    problems: tuple[ReadinessProblem, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "problems", tuple(self.problems))
+        if self.ready and self.problems:
+            raise WorkManagementContractError("A ready result must not contain problems.")
+        if not self.ready and not self.problems:
+            raise WorkManagementContractError("A non-ready result must contain at least one problem.")
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressUpdate:
+    """Progress information to publish for a work item."""
+
+    message: str
+    percent_complete: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "message", _normalize_text(self.message, "progress.message", max_length=10_000))
+        if self.percent_complete is not None and not 0 <= self.percent_complete <= 100:
+            raise WorkManagementContractError("percent_complete must be between 0 and 100.")
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class BlockerUpdate:
+    """A blocker to publish for a work item."""
+
+    reason: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "reason", _normalize_text(self.reason, "blocker.reason", max_length=10_000))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionUpdate:
+    """Completion evidence to publish for a work item."""
+
+    summary: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "summary", _normalize_text(self.summary, "completion.summary", max_length=10_000))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactUpdate:
+    """A reviewable artifact produced while executing a work item."""
+
+    name: str
+    url: str
+    media_type: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _normalize_text(self.name, "artifact.name", max_length=1_000))
+        object.__setattr__(self, "url", _normalize_url(self.url, "artifact.url", schemes=frozenset({"https"})))
+        object.__setattr__(self, "media_type", _normalize_text(self.media_type, "artifact.media_type", max_length=255))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateReceipt:
+    """Provider acknowledgement of a published update."""
+
+    external_key: str
+    kind: UpdateKind
+    provider_reference: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "external_key", _normalize_identifier(self.external_key))
+        object.__setattr__(
+            self,
+            "provider_reference",
+            _normalize_identifier(self.provider_reference, "provider_reference"),
+        )
+
+
+class WorkManagementProvider(ABC):
+    """Guarded application port implemented by Jira, ClickUp, or GitHub adapters."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> ProviderCapabilities:
+        """Declare the provider identity and supported operations."""
+
+    @final
+    async def retrieve_work_item(self, external_key: str) -> WorkItem:
+        """Retrieve one approved work item by its provider-neutral external key."""
+
+        self.capabilities.require(ProviderCapability.RETRIEVE_WORK_ITEM)
+        return await self._retrieve_work_item(_normalize_identifier(external_key))
+
+    @abstractmethod
+    async def _retrieve_work_item(self, external_key: str) -> WorkItem:
+        """Perform provider-specific work-item retrieval."""
+
+    @final
+    async def validate_readiness(self, work_item: WorkItem) -> ReadinessResult:
+        """Validate whether a normalized work item is ready for execution."""
+
+        self.capabilities.require(ProviderCapability.VALIDATE_READINESS)
+        return await self._validate_readiness(work_item)
+
+    async def _validate_readiness(self, work_item: WorkItem) -> ReadinessResult:
+        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.VALIDATE_READINESS)
+
+    @final
+    async def publish_progress(self, external_key: str, update: ProgressUpdate) -> UpdateReceipt:
+        """Publish a progress update."""
+
+        self.capabilities.require(ProviderCapability.PUBLISH_PROGRESS)
+        return await self._publish_progress(_normalize_identifier(external_key), update)
+
+    async def _publish_progress(self, external_key: str, update: ProgressUpdate) -> UpdateReceipt:
+        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_PROGRESS)
+
+    @final
+    async def publish_blocker(self, external_key: str, update: BlockerUpdate) -> UpdateReceipt:
+        """Publish a blocker update."""
+
+        self.capabilities.require(ProviderCapability.PUBLISH_BLOCKER)
+        return await self._publish_blocker(_normalize_identifier(external_key), update)
+
+    async def _publish_blocker(self, external_key: str, update: BlockerUpdate) -> UpdateReceipt:
+        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_BLOCKER)
+
+    @final
+    async def publish_completion(self, external_key: str, update: CompletionUpdate) -> UpdateReceipt:
+        """Publish a completion update."""
+
+        self.capabilities.require(ProviderCapability.PUBLISH_COMPLETION)
+        return await self._publish_completion(_normalize_identifier(external_key), update)
+
+    async def _publish_completion(self, external_key: str, update: CompletionUpdate) -> UpdateReceipt:
+        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_COMPLETION)
+
+    @final
+    async def publish_artifact(self, external_key: str, update: ArtifactUpdate) -> UpdateReceipt:
+        """Publish a reviewable artifact."""
+
+        self.capabilities.require(ProviderCapability.PUBLISH_ARTIFACT)
+        return await self._publish_artifact(_normalize_identifier(external_key), update)
+
+    async def _publish_artifact(self, external_key: str, update: ArtifactUpdate) -> UpdateReceipt:
+        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_ARTIFACT)

--- a/gearmeshing_ai/application/ports/work_management.py
+++ b/gearmeshing_ai/application/ports/work_management.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from types import MappingProxyType
-from typing import Any, Final, final
+from typing import Any, Final, Never, final
 from urllib.parse import urlsplit
-
 
 _MAX_IDENTIFIER_LENGTH: Final = 255
 _MAX_TEXT_LENGTH: Final = 100_000
@@ -32,7 +31,7 @@ class WorkManagementContractError(ValueError):
     """Base error raised before unsafe data reaches a provider adapter."""
 
 
-class UnsupportedProviderFeature(WorkManagementContractError):
+class UnsupportedProviderFeatureError(WorkManagementContractError):
     """Raised when an adapter does not declare a requested capability."""
 
     def __init__(self, provider_name: str, capability: ProviderCapability) -> None:
@@ -41,7 +40,7 @@ class UnsupportedProviderFeature(WorkManagementContractError):
         self.capability = capability
 
 
-class ProviderCapability(str, Enum):
+class ProviderCapability(StrEnum):
     """Operations that a work-management provider may support."""
 
     RETRIEVE_WORK_ITEM = "retrieve_work_item"
@@ -52,7 +51,7 @@ class ProviderCapability(str, Enum):
     PUBLISH_ARTIFACT = "publish_artifact"
 
 
-class UpdateKind(str, Enum):
+class UpdateKind(StrEnum):
     """Provider-neutral update categories."""
 
     PROGRESS = "progress"
@@ -61,23 +60,27 @@ class UpdateKind(str, Enum):
     ARTIFACT = "artifact"
 
 
+def _invalid(message: str) -> Never:
+    raise WorkManagementContractError(message)
+
+
 def _normalize_text(value: str, field_name: str, *, max_length: int = _MAX_TEXT_LENGTH) -> str:
     if not isinstance(value, str):
-        raise WorkManagementContractError(f"{field_name} must be a string.")
+        _invalid(f"{field_name} must be a string.")
     normalized = value.strip()
     if not normalized:
-        raise WorkManagementContractError(f"{field_name} must not be empty.")
+        _invalid(f"{field_name} must not be empty.")
     if len(normalized) > max_length:
-        raise WorkManagementContractError(f"{field_name} exceeds its maximum length.")
+        _invalid(f"{field_name} exceeds its maximum length.")
     if any(ord(character) < 32 and character not in "\n\t" for character in normalized):
-        raise WorkManagementContractError(f"{field_name} contains control characters.")
+        _invalid(f"{field_name} contains control characters.")
     return normalized
 
 
 def _normalize_identifier(value: str, field_name: str = "external_key") -> str:
     normalized = _normalize_text(value, field_name, max_length=_MAX_IDENTIFIER_LENGTH)
     if any(character.isspace() for character in normalized):
-        raise WorkManagementContractError(f"{field_name} must not contain whitespace.")
+        _invalid(f"{field_name} must not contain whitespace.")
     return normalized
 
 
@@ -85,11 +88,11 @@ def _normalize_url(value: str, field_name: str, *, schemes: frozenset[str]) -> s
     normalized = _normalize_text(value, field_name, max_length=2_048)
     parsed = urlsplit(normalized)
     if parsed.scheme.lower() not in schemes:
-        raise WorkManagementContractError(f"{field_name} uses an unsupported URL scheme.")
+        _invalid(f"{field_name} uses an unsupported URL scheme.")
     if parsed.scheme.lower() == "https" and not parsed.hostname:
-        raise WorkManagementContractError(f"{field_name} must include a host.")
+        _invalid(f"{field_name} must include a host.")
     if parsed.username is not None or parsed.password is not None:
-        raise WorkManagementContractError(f"{field_name} must not contain credentials.")
+        _invalid(f"{field_name} must not contain credentials.")
     return normalized
 
 
@@ -98,17 +101,17 @@ def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
         frozen: dict[str, Any] = {}
         for key, item in value.items():
             if not isinstance(key, str):
-                raise WorkManagementContractError(f"{path} keys must be strings.")
+                _invalid(f"{path} keys must be strings.")
             normalized_key = _normalize_text(key, f"{path} key", max_length=128)
             if normalized_key.lower() in _SENSITIVE_METADATA_KEYS:
-                raise WorkManagementContractError(f"{path} contains a sensitive key: {normalized_key!r}.")
+                _invalid(f"{path} contains a sensitive key: {normalized_key!r}.")
             frozen[normalized_key] = _freeze_metadata(item, path=f"{path}.{normalized_key}")
         return MappingProxyType(frozen)
     if isinstance(value, (list, tuple)):
         return tuple(_freeze_metadata(item, path=path) for item in value)
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
-    raise WorkManagementContractError(f"{path} contains an unsupported value type.")
+    _invalid(f"{path} contains an unsupported value type.")
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,13 +125,12 @@ class ProviderCapabilities:
         object.__setattr__(self, "provider_name", _normalize_identifier(self.provider_name, "provider_name"))
         object.__setattr__(self, "supported", frozenset(self.supported))
         if not all(isinstance(capability, ProviderCapability) for capability in self.supported):
-            raise WorkManagementContractError("supported must contain ProviderCapability values.")
+            _invalid("supported must contain ProviderCapability values.")
 
     def require(self, capability: ProviderCapability) -> None:
         """Raise explicitly when the provider does not support an operation."""
-
         if capability not in self.supported:
-            raise UnsupportedProviderFeature(self.provider_name, capability)
+            raise UnsupportedProviderFeatureError(self.provider_name, capability)
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,10 +169,10 @@ class WorkItem:
             for criterion in self.acceptance_criteria
         )
         if not criteria:
-            raise WorkManagementContractError("acceptance_criteria must not be empty.")
+            _invalid("acceptance_criteria must not be empty.")
         object.__setattr__(self, "acceptance_criteria", criteria)
         if not isinstance(self.repository, WorkRepository):
-            raise WorkManagementContractError("repository must be a WorkRepository.")
+            _invalid("repository must be a WorkRepository.")
         object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
 
 
@@ -196,9 +198,9 @@ class ReadinessResult:
     def __post_init__(self) -> None:
         object.__setattr__(self, "problems", tuple(self.problems))
         if self.ready and self.problems:
-            raise WorkManagementContractError("A ready result must not contain problems.")
+            _invalid("A ready result must not contain problems.")
         if not self.ready and not self.problems:
-            raise WorkManagementContractError("A non-ready result must contain at least one problem.")
+            _invalid("A non-ready result must contain at least one problem.")
 
 
 @dataclass(frozen=True, slots=True)
@@ -212,7 +214,7 @@ class ProgressUpdate:
     def __post_init__(self) -> None:
         object.__setattr__(self, "message", _normalize_text(self.message, "progress.message", max_length=10_000))
         if self.percent_complete is not None and not 0 <= self.percent_complete <= 100:
-            raise WorkManagementContractError("percent_complete must be between 0 and 100.")
+            _invalid("percent_complete must be between 0 and 100.")
         object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
 
 
@@ -284,7 +286,6 @@ class WorkManagementProvider(ABC):
     @final
     async def retrieve_work_item(self, external_key: str) -> WorkItem:
         """Retrieve one approved work item by its provider-neutral external key."""
-
         self.capabilities.require(ProviderCapability.RETRIEVE_WORK_ITEM)
         return await self._retrieve_work_item(_normalize_identifier(external_key))
 
@@ -295,49 +296,44 @@ class WorkManagementProvider(ABC):
     @final
     async def validate_readiness(self, work_item: WorkItem) -> ReadinessResult:
         """Validate whether a normalized work item is ready for execution."""
-
         self.capabilities.require(ProviderCapability.VALIDATE_READINESS)
         return await self._validate_readiness(work_item)
 
     async def _validate_readiness(self, work_item: WorkItem) -> ReadinessResult:
-        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.VALIDATE_READINESS)
+        raise UnsupportedProviderFeatureError(self.capabilities.provider_name, ProviderCapability.VALIDATE_READINESS)
 
     @final
     async def publish_progress(self, external_key: str, update: ProgressUpdate) -> UpdateReceipt:
         """Publish a progress update."""
-
         self.capabilities.require(ProviderCapability.PUBLISH_PROGRESS)
         return await self._publish_progress(_normalize_identifier(external_key), update)
 
     async def _publish_progress(self, external_key: str, update: ProgressUpdate) -> UpdateReceipt:
-        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_PROGRESS)
+        raise UnsupportedProviderFeatureError(self.capabilities.provider_name, ProviderCapability.PUBLISH_PROGRESS)
 
     @final
     async def publish_blocker(self, external_key: str, update: BlockerUpdate) -> UpdateReceipt:
         """Publish a blocker update."""
-
         self.capabilities.require(ProviderCapability.PUBLISH_BLOCKER)
         return await self._publish_blocker(_normalize_identifier(external_key), update)
 
     async def _publish_blocker(self, external_key: str, update: BlockerUpdate) -> UpdateReceipt:
-        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_BLOCKER)
+        raise UnsupportedProviderFeatureError(self.capabilities.provider_name, ProviderCapability.PUBLISH_BLOCKER)
 
     @final
     async def publish_completion(self, external_key: str, update: CompletionUpdate) -> UpdateReceipt:
         """Publish a completion update."""
-
         self.capabilities.require(ProviderCapability.PUBLISH_COMPLETION)
         return await self._publish_completion(_normalize_identifier(external_key), update)
 
     async def _publish_completion(self, external_key: str, update: CompletionUpdate) -> UpdateReceipt:
-        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_COMPLETION)
+        raise UnsupportedProviderFeatureError(self.capabilities.provider_name, ProviderCapability.PUBLISH_COMPLETION)
 
     @final
     async def publish_artifact(self, external_key: str, update: ArtifactUpdate) -> UpdateReceipt:
         """Publish a reviewable artifact."""
-
         self.capabilities.require(ProviderCapability.PUBLISH_ARTIFACT)
         return await self._publish_artifact(_normalize_identifier(external_key), update)
 
     async def _publish_artifact(self, external_key: str, update: ArtifactUpdate) -> UpdateReceipt:
-        raise UnsupportedProviderFeature(self.capabilities.provider_name, ProviderCapability.PUBLISH_ARTIFACT)
+        raise UnsupportedProviderFeatureError(self.capabilities.provider_name, ProviderCapability.PUBLISH_ARTIFACT)

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -20,6 +20,7 @@ from gearmeshing_ai.application.ports.work_management import (
     UpdateKind,
     UpdateReceipt,
     WorkItem,
+    WorkManagementContractError,
     WorkManagementProvider,
     WorkRepository,
 )
@@ -165,3 +166,21 @@ async def test_unsupported_provider_features_fail_explicitly() -> None:
 
     assert error.value.capability is ProviderCapability.PUBLISH_PROGRESS
     assert provider.calls == []
+
+
+def test_rejects_unsafe_identifiers_urls_and_metadata() -> None:
+    with pytest.raises(WorkManagementContractError):
+        WorkRepository("http://github.com/example/project")
+    with pytest.raises(WorkManagementContractError):
+        WorkItem(
+            external_key="WORK 42",
+            title="Title",
+            specification="Specification",
+            acceptance_criteria=("Criterion",),
+            repository=WorkRepository("https://github.com/example/project"),
+        )
+
+    secret = "not-for-error-output"
+    with pytest.raises(WorkManagementContractError) as error:
+        ProgressUpdate("Started", metadata={"api_token": secret})
+    assert secret not in str(error.value)

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -16,7 +16,7 @@ from gearmeshing_ai.application.ports.work_management import (
     ProviderCapabilities,
     ProviderCapability,
     ReadinessResult,
-    UnsupportedProviderFeature,
+    UnsupportedProviderFeatureError,
     UpdateKind,
     UpdateReceipt,
     WorkItem,
@@ -24,7 +24,6 @@ from gearmeshing_ai.application.ports.work_management import (
     WorkManagementProvider,
     WorkRepository,
 )
-
 
 ALL_CAPABILITIES = frozenset(ProviderCapability)
 
@@ -95,7 +94,7 @@ def test_work_item_data_is_deeply_immutable() -> None:
     item = make_work_item()
 
     with pytest.raises(FrozenInstanceError):
-        setattr(item, "title", "Changed")
+        item.title = "Changed"  # type: ignore[misc]
     with pytest.raises(TypeError):
         operator.setitem(item.metadata, "priority", "low")
     with pytest.raises(TypeError):
@@ -161,7 +160,7 @@ async def test_publishes_artifacts_through_the_normalized_contract() -> None:
 async def test_unsupported_provider_features_fail_explicitly() -> None:
     provider = RecordingProvider(frozenset({ProviderCapability.RETRIEVE_WORK_ITEM}))
 
-    with pytest.raises(UnsupportedProviderFeature) as error:
+    with pytest.raises(UnsupportedProviderFeatureError) as error:
         await provider.publish_progress("WORK-42", ProgressUpdate("Started"))
 
     assert error.value.capability is ProviderCapability.PUBLISH_PROGRESS

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -120,3 +120,14 @@ async def test_publishes_progress_through_the_normalized_contract() -> None:
 
     assert receipt == UpdateReceipt("WORK-42", UpdateKind.PROGRESS, "progress-1")
     assert provider.calls == [("progress", "WORK-42", update)]
+
+
+@pytest.mark.asyncio
+async def test_publishes_blockers_through_the_normalized_contract() -> None:
+    provider = RecordingProvider()
+    update = BlockerUpdate("Approval is required")
+
+    receipt = await provider.publish_blocker("WORK-42", update)
+
+    assert receipt == UpdateReceipt("WORK-42", UpdateKind.BLOCKER, "blocker-1")
+    assert provider.calls == [("blocker", "WORK-42", update)]

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -16,6 +16,7 @@ from gearmeshing_ai.application.ports.work_management import (
     ProviderCapabilities,
     ProviderCapability,
     ReadinessResult,
+    UnsupportedProviderFeature,
     UpdateKind,
     UpdateReceipt,
     WorkItem,
@@ -153,3 +154,14 @@ async def test_publishes_artifacts_through_the_normalized_contract() -> None:
 
     assert receipt == UpdateReceipt("WORK-42", UpdateKind.ARTIFACT, "artifact-1")
     assert provider.calls == [("artifact", "WORK-42", update)]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_provider_features_fail_explicitly() -> None:
+    provider = RecordingProvider(frozenset({ProviderCapability.RETRIEVE_WORK_ITEM}))
+
+    with pytest.raises(UnsupportedProviderFeature) as error:
+        await provider.publish_progress("WORK-42", ProgressUpdate("Started"))
+
+    assert error.value.capability is ProviderCapability.PUBLISH_PROGRESS
+    assert provider.calls == []

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import operator
+from dataclasses import FrozenInstanceError
 from typing import Any
 
 import pytest
@@ -85,3 +87,14 @@ async def test_retrieves_a_normalized_work_item_by_external_key() -> None:
     assert item.specification == "Execute an approved specification."
     assert item.acceptance_criteria == ("Emit reviewable evidence.",)
     assert item.repository == WorkRepository("https://github.com/example/project", "main")
+
+
+def test_work_item_data_is_deeply_immutable() -> None:
+    item = make_work_item()
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(item, "title", "Changed")
+    with pytest.raises(TypeError):
+        operator.setitem(item.metadata, "priority", "low")
+    with pytest.raises(TypeError):
+        operator.setitem(item.metadata["labels"], 0, "changed")

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from gearmeshing_ai.application.ports.work_management import (
     ArtifactUpdate,
     BlockerUpdate,
@@ -70,3 +72,16 @@ class RecordingProvider(WorkManagementProvider):
     async def _publish_artifact(self, external_key: str, update: ArtifactUpdate) -> UpdateReceipt:
         self.calls.append(("artifact", external_key, update))
         return UpdateReceipt(external_key, UpdateKind.ARTIFACT, "artifact-1")
+
+
+@pytest.mark.asyncio
+async def test_retrieves_a_normalized_work_item_by_external_key() -> None:
+    provider = RecordingProvider()
+
+    item = await provider.retrieve_work_item("  WORK-42  ")
+
+    assert provider.calls == [("retrieve", "WORK-42", None)]
+    assert item.title == "Implement guarded execution"
+    assert item.specification == "Execute an approved specification."
+    assert item.acceptance_criteria == ("Emit reviewable evidence.",)
+    assert item.repository == WorkRepository("https://github.com/example/project", "main")

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -98,3 +98,14 @@ def test_work_item_data_is_deeply_immutable() -> None:
         operator.setitem(item.metadata, "priority", "low")
     with pytest.raises(TypeError):
         operator.setitem(item.metadata["labels"], 0, "changed")
+
+
+@pytest.mark.asyncio
+async def test_returns_a_provider_neutral_readiness_result() -> None:
+    provider = RecordingProvider()
+    item = make_work_item()
+
+    result = await provider.validate_readiness(item)
+
+    assert result == ReadinessResult(ready=True)
+    assert provider.calls == [("readiness", "WORK-42", None)]

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -1,0 +1,72 @@
+"""Contract tests for provider-neutral work-management adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gearmeshing_ai.application.ports.work_management import (
+    ArtifactUpdate,
+    BlockerUpdate,
+    CompletionUpdate,
+    ProgressUpdate,
+    ProviderCapabilities,
+    ProviderCapability,
+    ReadinessResult,
+    UpdateKind,
+    UpdateReceipt,
+    WorkItem,
+    WorkManagementProvider,
+    WorkRepository,
+)
+
+
+ALL_CAPABILITIES = frozenset(ProviderCapability)
+
+
+def make_work_item() -> WorkItem:
+    """Build a normalized item shared by contract scenarios."""
+
+    return WorkItem(
+        external_key="WORK-42",
+        title="  Implement guarded execution  ",
+        specification="  Execute an approved specification.  ",
+        acceptance_criteria=("  Emit reviewable evidence.  ",),
+        repository=WorkRepository("https://github.com/example/project"),
+        metadata={"priority": "high", "labels": ["mvp-1"]},
+    )
+
+
+class RecordingProvider(WorkManagementProvider):
+    """Minimal reusable adapter used to exercise the application port."""
+
+    def __init__(self, supported: frozenset[ProviderCapability] = ALL_CAPABILITIES) -> None:
+        self._capabilities = ProviderCapabilities("recording", supported)
+        self.calls: list[tuple[str, str, Any]] = []
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return self._capabilities
+
+    async def _retrieve_work_item(self, external_key: str) -> WorkItem:
+        self.calls.append(("retrieve", external_key, None))
+        return make_work_item()
+
+    async def _validate_readiness(self, work_item: WorkItem) -> ReadinessResult:
+        self.calls.append(("readiness", work_item.external_key, None))
+        return ReadinessResult(ready=True)
+
+    async def _publish_progress(self, external_key: str, update: ProgressUpdate) -> UpdateReceipt:
+        self.calls.append(("progress", external_key, update))
+        return UpdateReceipt(external_key, UpdateKind.PROGRESS, "progress-1")
+
+    async def _publish_blocker(self, external_key: str, update: BlockerUpdate) -> UpdateReceipt:
+        self.calls.append(("blocker", external_key, update))
+        return UpdateReceipt(external_key, UpdateKind.BLOCKER, "blocker-1")
+
+    async def _publish_completion(self, external_key: str, update: CompletionUpdate) -> UpdateReceipt:
+        self.calls.append(("completion", external_key, update))
+        return UpdateReceipt(external_key, UpdateKind.COMPLETION, "completion-1")
+
+    async def _publish_artifact(self, external_key: str, update: ArtifactUpdate) -> UpdateReceipt:
+        self.calls.append(("artifact", external_key, update))
+        return UpdateReceipt(external_key, UpdateKind.ARTIFACT, "artifact-1")

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -109,3 +109,14 @@ async def test_returns_a_provider_neutral_readiness_result() -> None:
 
     assert result == ReadinessResult(ready=True)
     assert provider.calls == [("readiness", "WORK-42", None)]
+
+
+@pytest.mark.asyncio
+async def test_publishes_progress_through_the_normalized_contract() -> None:
+    provider = RecordingProvider()
+    update = ProgressUpdate("Implementation started", percent_complete=25)
+
+    receipt = await provider.publish_progress("WORK-42", update)
+
+    assert receipt == UpdateReceipt("WORK-42", UpdateKind.PROGRESS, "progress-1")
+    assert provider.calls == [("progress", "WORK-42", update)]

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import operator
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, fields
 from typing import Any
 
 import pytest
@@ -184,3 +184,15 @@ def test_rejects_unsafe_identifiers_urls_and_metadata() -> None:
     with pytest.raises(WorkManagementContractError) as error:
         ProgressUpdate("Started", metadata={"api_token": secret})
     assert secret not in str(error.value)
+
+
+def test_contract_has_no_jira_specific_fields_or_provider_identity() -> None:
+    public_names = {
+        *(field.name for field in fields(WorkItem)),
+        *(field.name for field in fields(ProgressUpdate)),
+        *(name for name in dir(WorkManagementProvider) if not name.startswith("_")),
+    }
+
+    assert not any("jira" in name.lower() for name in public_names)
+    assert ProviderCapabilities("clickup", ALL_CAPABILITIES).provider_name == "clickup"
+    assert ProviderCapabilities("github-issues", ALL_CAPABILITIES).provider_name == "github-issues"

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -131,3 +131,14 @@ async def test_publishes_blockers_through_the_normalized_contract() -> None:
 
     assert receipt == UpdateReceipt("WORK-42", UpdateKind.BLOCKER, "blocker-1")
     assert provider.calls == [("blocker", "WORK-42", update)]
+
+
+@pytest.mark.asyncio
+async def test_publishes_completion_through_the_normalized_contract() -> None:
+    provider = RecordingProvider()
+    update = CompletionUpdate("All acceptance criteria passed")
+
+    receipt = await provider.publish_completion("WORK-42", update)
+
+    assert receipt == UpdateReceipt("WORK-42", UpdateKind.COMPLETION, "completion-1")
+    assert provider.calls == [("completion", "WORK-42", update)]

--- a/test/contract_test/application/test_work_management.py
+++ b/test/contract_test/application/test_work_management.py
@@ -142,3 +142,14 @@ async def test_publishes_completion_through_the_normalized_contract() -> None:
 
     assert receipt == UpdateReceipt("WORK-42", UpdateKind.COMPLETION, "completion-1")
     assert provider.calls == [("completion", "WORK-42", update)]
+
+
+@pytest.mark.asyncio
+async def test_publishes_artifacts_through_the_normalized_contract() -> None:
+    provider = RecordingProvider()
+    update = ArtifactUpdate("Draft pull request", "https://github.com/example/project/pull/1", "text/html")
+
+    receipt = await provider.publish_artifact("WORK-42", update)
+
+    assert receipt == UpdateReceipt("WORK-42", UpdateKind.ARTIFACT, "artifact-1")
+    assert provider.calls == [("artifact", "WORK-42", update)]

--- a/test/unit_test/adapters/jira_work_management_fixtures.py
+++ b/test/unit_test/adapters/jira_work_management_fixtures.py
@@ -29,9 +29,7 @@ def jira_description(*criteria: str) -> dict[str, Any]:
                 "content": [
                     {
                         "type": "listItem",
-                        "content": [
-                            {"type": "paragraph", "content": [{"type": "text", "text": criterion}]}
-                        ],
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": criterion}]}],
                     }
                     for criterion in criteria
                 ],

--- a/test/unit_test/adapters/jira_work_management_fixtures.py
+++ b/test/unit_test/adapters/jira_work_management_fixtures.py
@@ -1,0 +1,59 @@
+"""Pure Jira payload fixtures for work-management adapter tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def jira_description(*criteria: str) -> dict[str, Any]:
+    content: list[dict[str, Any]] = [
+        {
+            "type": "heading",
+            "attrs": {"level": 2},
+            "content": [{"type": "text", "text": "User Value"}],
+        },
+        {
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "Deliver only the approved behavior."}],
+        },
+        {
+            "type": "heading",
+            "attrs": {"level": 2},
+            "content": [{"type": "text", "text": "Acceptance Criteria"}],
+        },
+    ]
+    if criteria:
+        content.append(
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {"type": "paragraph", "content": [{"type": "text", "text": criterion}]}
+                        ],
+                    }
+                    for criterion in criteria
+                ],
+            }
+        )
+    return {"type": "doc", "version": 1, "content": content}
+
+
+def jira_issue_payload(
+    *,
+    issue_type: str = "Story",
+    criteria: tuple[str, ...] = ("The approved result is observable.",),
+    repository_url: str | None = "https://github.com/example/gearmeshing-ai",
+    labels: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "key": "GMAI-17",
+        "fields": {
+            "summary": "Load approved Jira work item",
+            "description": jira_description(*criteria),
+            "issuetype": {"name": issue_type},
+            "labels": ["mvp-1", "spec-ready"] if labels is None else labels,
+            "customfield_12345": repository_url,
+        },
+    }

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -10,6 +10,7 @@ from gearmeshing_ai.adapters.jira_work_management import (
     JiraWorkManagementConfig,
     JiraWorkManagementProvider,
 )
+from gearmeshing_ai.application.ports.work_management import ReadinessProblem, ReadinessResult, UpdateKind
 from test.unit_test.adapters.jira_work_management_fixtures import jira_issue_payload
 
 
@@ -106,3 +107,31 @@ async def test_inaccessible_issue_maps_to_safe_authorization_error() -> None:
 
     assert secret not in str(captured.value)
     assert "not permitted" in str(captured.value)
+
+
+@pytest.mark.asyncio
+async def test_blocked_validation_is_publishable_as_jira_comment() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/rest/api/3/issue/GMAI-17/comment"
+        assert b"missing_repository" in request.content
+        return httpx.Response(201, json={"id": "10042"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        receipt = await provider.publish_readiness(
+            "GMAI-17",
+            ReadinessResult(
+                ready=False,
+                problems=(ReadinessProblem("missing_repository", "Set the approved repository URL."),),
+            ),
+        )
+
+    assert receipt.kind is UpdateKind.BLOCKER
+    assert receipt.provider_reference == "10042"

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -327,3 +327,15 @@ async def test_oversized_stream_is_stopped_and_closed_at_response_bound() -> Non
 
     assert stream.chunks_read == 2
     assert stream.closed is True
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator, unused-ignore]
+    "site_url",
+    ["https://mock.atlassian.net:not-a-port", "https://mock.atlassian.net:99999"],
+)
+def test_config_rejects_invalid_jira_site_ports(site_url: str) -> None:
+    with pytest.raises(ValueError, match="valid host and port"):
+        JiraWorkManagementConfig(
+            site_url=site_url,
+            repository_url_field="customfield_12345",
+        )

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -20,7 +20,7 @@ from gearmeshing_ai.application.ports.work_management import ReadinessProblem, R
 from test.unit_test.adapters.jira_work_management_fixtures import jira_issue_payload
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_ready_issue_is_normalized_without_inventing_requirements() -> None:
     payload = jira_issue_payload(criteria=("First approved outcome.", "Second approved outcome."))
 
@@ -49,7 +49,7 @@ async def test_ready_issue_is_normalized_without_inventing_requirements() -> Non
     assert readiness.ready is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_incomplete_issue_reports_missing_criteria_and_repository() -> None:
     payload = jira_issue_payload(criteria=(), repository_url=None)
 
@@ -73,7 +73,7 @@ async def test_incomplete_issue_reports_missing_criteria_and_repository() -> Non
     assert "customfield_12345" in problems["missing_repository"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_unsupported_issue_type_is_blocked() -> None:
     payload = jira_issue_payload(issue_type="Epic")
 
@@ -94,7 +94,7 @@ async def test_unsupported_issue_type_is_blocked() -> None:
     assert "Story, Task" in captured.value.readiness.problems[0].message
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_inaccessible_issue_maps_to_safe_authorization_error() -> None:
     secret = "not-a-real-token"
     async with httpx.AsyncClient(
@@ -115,7 +115,7 @@ async def test_inaccessible_issue_maps_to_safe_authorization_error() -> None:
     assert "not permitted" in str(captured.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_blocked_validation_is_publishable_as_jira_comment() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
@@ -143,7 +143,7 @@ async def test_blocked_validation_is_publishable_as_jira_comment() -> None:
     assert receipt.provider_reference == "10042"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_issue_without_spec_ready_label_is_blocked() -> None:
     payload = jira_issue_payload(labels=["mvp-1"])
 
@@ -164,7 +164,7 @@ async def test_issue_without_spec_ready_label_is_blocked() -> None:
     assert "spec-ready" in captured.value.readiness.problems[-1].message
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_rate_limit_retries_are_bounded() -> None:
     attempts = 0
     delays: list[float] = []
@@ -195,7 +195,7 @@ async def test_rate_limit_retries_are_bounded() -> None:
     assert delays == [1.5]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_unsafe_issue_key_is_rejected_before_http_request() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         pytest.fail(f"Unexpected request: {request.url}")
@@ -225,7 +225,7 @@ def test_config_defensively_freezes_supported_issue_types() -> None:
     assert config.supported_issue_types == frozenset({"Story"})
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator, unused-ignore]
     ("field_name", "value", "message"),
     [
         ("request_timeout_seconds", float("nan"), "positive finite number"),
@@ -250,8 +250,10 @@ def test_config_rejects_unsafe_numeric_bounds(field_name: str, value: object, me
         JiraWorkManagementConfig(**values)
 
 
-@pytest.mark.parametrize("retry_after", ["nan", "inf", "-inf"])
-@pytest.mark.asyncio
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator, unused-ignore]
+    "retry_after", ["nan", "inf", "-inf"]
+)
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
 async def test_non_finite_retry_after_uses_bounded_exponential_delay(retry_after: str) -> None:
     attempts = 0
     delays: list[float] = []

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from gearmeshing_ai.adapters.jira_errors import JiraAuthorizationError, JiraIssueValidationError
+from gearmeshing_ai.adapters.jira_errors import (
+    JiraAuthorizationError,
+    JiraIssueValidationError,
+    JiraRateLimitError,
+)
 from gearmeshing_ai.adapters.jira_work_management import (
     JiraWorkManagementConfig,
     JiraWorkManagementProvider,
@@ -156,3 +160,34 @@ async def test_issue_without_spec_ready_label_is_blocked() -> None:
 
     assert captured.value.readiness.problems[-1].code == "not_spec_ready"
     assert "spec-ready" in captured.value.readiness.problems[-1].message
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_retries_are_bounded() -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(429, headers={"Retry-After": "60"}, json={})
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+                max_attempts=2,
+                max_retry_delay_seconds=1.5,
+            ),
+            sleep=record_sleep,
+        )
+        with pytest.raises(JiraRateLimitError):
+            await provider.retrieve_work_item("GMAI-17")
+
+    assert attempts == 2
+    assert delays == [1.5]

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -135,3 +135,24 @@ async def test_blocked_validation_is_publishable_as_jira_comment() -> None:
 
     assert receipt.kind is UpdateKind.BLOCKER
     assert receipt.provider_reference == "10042"
+
+
+@pytest.mark.asyncio
+async def test_issue_without_spec_ready_label_is_blocked() -> None:
+    payload = jira_issue_payload(labels=["mvp-1"])
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=payload))
+    ) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        with pytest.raises(JiraIssueValidationError) as captured:
+            await provider.retrieve_work_item("GMAI-17")
+
+    assert captured.value.readiness.problems[-1].code == "not_spec_ready"
+    assert "spec-ready" in captured.value.readiness.problems[-1].message

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -191,3 +191,20 @@ async def test_rate_limit_retries_are_bounded() -> None:
 
     assert attempts == 2
     assert delays == [1.5]
+
+
+@pytest.mark.asyncio
+async def test_unsafe_issue_key_is_rejected_before_http_request() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        pytest.fail(f"Unexpected request: {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        with pytest.raises(ValueError, match="canonical Jira issue key"):
+            await provider.retrieve_work_item("GMAI-17/../admin")

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -280,3 +280,12 @@ async def test_non_finite_retry_after_uses_bounded_exponential_delay(retry_after
 
     assert work_item.external_key == "GMAI-17"
     assert delays == [1.0, 1.5]
+
+
+def test_config_rejects_text_as_issue_type_collection() -> None:
+    with pytest.raises(ValueError, match="must be a collection"):
+        JiraWorkManagementConfig(
+            site_url="https://mock.atlassian.net",
+            repository_url_field="customfield_12345",
+            supported_issue_types="Story",  # type: ignore[arg-type]
+        )

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -1,0 +1,41 @@
+"""Tests for the Jira work-management adapter."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from gearmeshing_ai.adapters.jira_work_management import (
+    JiraWorkManagementConfig,
+    JiraWorkManagementProvider,
+)
+from test.unit_test.adapters.jira_work_management_fixtures import jira_issue_payload
+
+
+@pytest.mark.asyncio
+async def test_ready_issue_is_normalized_without_inventing_requirements() -> None:
+    payload = jira_issue_payload(criteria=("First approved outcome.", "Second approved outcome."))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/api/3/issue/GMAI-17"
+        assert request.url.params["fields"] == "summary,description,issuetype,labels,customfield_12345"
+        return httpx.Response(200, json=payload)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        work_item = await provider.retrieve_work_item("GMAI-17")
+        readiness = await provider.validate_readiness(work_item)
+
+    assert work_item.title == "Load approved Jira work item"
+    assert work_item.specification.startswith("User Value\n\nDeliver only the approved behavior.")
+    assert work_item.acceptance_criteria == ("First approved outcome.", "Second approved outcome.")
+    assert work_item.repository.url == "https://github.com/example/gearmeshing-ai"
+    assert work_item.repository.default_branch == "main"
+    assert work_item.metadata["labels"] == ("mvp-1", "spec-ready")
+    assert readiness.ready is True

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from gearmeshing_ai.adapters.jira_errors import JiraIssueValidationError
+from gearmeshing_ai.adapters.jira_errors import JiraAuthorizationError, JiraIssueValidationError
 from gearmeshing_ai.adapters.jira_work_management import (
     JiraWorkManagementConfig,
     JiraWorkManagementProvider,
@@ -85,3 +85,24 @@ async def test_unsupported_issue_type_is_blocked() -> None:
 
     assert captured.value.readiness.problems[0].code == "unsupported_issue_type"
     assert "Story, Task" in captured.value.readiness.problems[0].message
+
+
+@pytest.mark.asyncio
+async def test_inaccessible_issue_maps_to_safe_authorization_error() -> None:
+    secret = "not-a-real-token"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(403, json={"errorMessages": [secret]})),
+        headers={"Authorization": f"Basic {secret}"},
+    ) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        with pytest.raises(JiraAuthorizationError) as captured:
+            await provider.retrieve_work_item("GMAI-17")
+
+    assert secret not in str(captured.value)
+    assert "not permitted" in str(captured.value)

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -64,3 +64,24 @@ async def test_incomplete_issue_reports_missing_criteria_and_repository() -> Non
     assert "no criteria will be inferred" in problems["missing_acceptance_criteria"]
     assert "missing_repository" in problems
     assert "customfield_12345" in problems["missing_repository"]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_issue_type_is_blocked() -> None:
+    payload = jira_issue_payload(issue_type="Epic")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=payload))
+    ) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        with pytest.raises(JiraIssueValidationError) as captured:
+            await provider.retrieve_work_item("GMAI-17")
+
+    assert captured.value.readiness.problems[0].code == "unsupported_issue_type"
+    assert "Story, Task" in captured.value.readiness.problems[0].message

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 
 import httpx
@@ -11,6 +12,7 @@ from gearmeshing_ai.adapters.jira_errors import (
     JiraAuthorizationError,
     JiraIssueValidationError,
     JiraRateLimitError,
+    JiraTransportError,
 )
 from gearmeshing_ai.adapters.jira_work_management import (
     JiraWorkManagementConfig,
@@ -291,3 +293,37 @@ def test_config_rejects_text_as_issue_type_collection() -> None:
             repository_url_field="customfield_12345",
             supported_issue_types="Story",  # type: ignore[arg-type]
         )
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
+async def test_oversized_stream_is_stopped_and_closed_at_response_bound() -> None:
+    class TrackedStream(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.chunks_read = 0
+            self.closed = False
+
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            for chunk in (b'{"ok":', b'"0123456789"', b"}"):
+                self.chunks_read += 1
+                yield chunk
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    stream = TrackedStream()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, stream=stream))
+    ) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+                max_response_bytes=10,
+            ),
+        )
+        with pytest.raises(JiraTransportError, match="larger than the configured bound"):
+            await provider.retrieve_work_item("GMAI-17")
+
+    assert stream.chunks_read == 2
+    assert stream.closed is True

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -339,3 +339,23 @@ def test_config_rejects_invalid_jira_site_ports(site_url: str) -> None:
             site_url=site_url,
             repository_url_field="customfield_12345",
         )
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator, unused-ignore]
+async def test_httpx_invalid_url_maps_to_typed_transport_error() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        message = "synthetic invalid URL"
+        raise httpx.InvalidURL(message)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        with pytest.raises(JiraTransportError, match="configured request bound") as captured:
+            await provider.retrieve_work_item("GMAI-17")
+
+    assert isinstance(captured.value.__cause__, httpx.InvalidURL)

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -208,3 +208,16 @@ async def test_unsafe_issue_key_is_rejected_before_http_request() -> None:
         )
         with pytest.raises(ValueError, match="canonical Jira issue key"):
             await provider.retrieve_work_item("GMAI-17/../admin")
+
+
+def test_config_defensively_freezes_supported_issue_types() -> None:
+    mutable_issue_types = {"Story"}
+
+    config = JiraWorkManagementConfig(
+        site_url="https://mock.atlassian.net",
+        repository_url_field="customfield_12345",
+        supported_issue_types=mutable_issue_types,  # type: ignore[arg-type]
+    )
+    mutable_issue_types.add("Epic")
+
+    assert config.supported_issue_types == frozenset({"Story"})

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from gearmeshing_ai.adapters.jira_errors import JiraIssueValidationError
 from gearmeshing_ai.adapters.jira_work_management import (
     JiraWorkManagementConfig,
     JiraWorkManagementProvider,
@@ -39,3 +40,27 @@ async def test_ready_issue_is_normalized_without_inventing_requirements() -> Non
     assert work_item.repository.default_branch == "main"
     assert work_item.metadata["labels"] == ("mvp-1", "spec-ready")
     assert readiness.ready is True
+
+
+@pytest.mark.asyncio
+async def test_incomplete_issue_reports_missing_criteria_and_repository() -> None:
+    payload = jira_issue_payload(criteria=(), repository_url=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=payload))
+    ) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+            ),
+        )
+        with pytest.raises(JiraIssueValidationError) as captured:
+            await provider.retrieve_work_item("GMAI-17")
+
+    problems = {problem.code: problem.message for problem in captured.value.readiness.problems}
+    assert "missing_acceptance_criteria" in problems
+    assert "no criteria will be inferred" in problems["missing_acceptance_criteria"]
+    assert "missing_repository" in problems
+    assert "customfield_12345" in problems["missing_repository"]

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 import pytest
 
@@ -221,3 +223,28 @@ def test_config_defensively_freezes_supported_issue_types() -> None:
     mutable_issue_types.add("Epic")
 
     assert config.supported_issue_types == frozenset({"Story"})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "message"),
+    [
+        ("request_timeout_seconds", float("nan"), "positive finite number"),
+        ("request_timeout_seconds", float("inf"), "positive finite number"),
+        ("request_timeout_seconds", True, "positive finite number"),
+        ("max_retry_delay_seconds", float("-inf"), "non-negative finite number"),
+        ("max_retry_delay_seconds", True, "non-negative finite number"),
+        ("max_attempts", True, "integer between one and five"),
+        ("max_attempts", 2.5, "integer between one and five"),
+        ("max_response_bytes", True, "positive integer"),
+        ("max_response_bytes", 1024.5, "positive integer"),
+    ],
+)
+def test_config_rejects_unsafe_numeric_bounds(field_name: str, value: object, message: str) -> None:
+    values: dict[str, Any] = {
+        "site_url": "https://mock.atlassian.net",
+        "repository_url_field": "customfield_12345",
+        field_name: value,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        JiraWorkManagementConfig(**values)

--- a/test/unit_test/adapters/test_jira_work_management.py
+++ b/test/unit_test/adapters/test_jira_work_management.py
@@ -248,3 +248,35 @@ def test_config_rejects_unsafe_numeric_bounds(field_name: str, value: object, me
 
     with pytest.raises(ValueError, match=message):
         JiraWorkManagementConfig(**values)
+
+
+@pytest.mark.parametrize("retry_after", ["nan", "inf", "-inf"])
+@pytest.mark.asyncio
+async def test_non_finite_retry_after_uses_bounded_exponential_delay(retry_after: str) -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            return httpx.Response(429, headers={"Retry-After": retry_after}, json={})
+        return httpx.Response(200, json=jira_issue_payload())
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        provider = JiraWorkManagementProvider(
+            client,
+            JiraWorkManagementConfig(
+                site_url="https://mock.atlassian.net",
+                repository_url_field="customfield_12345",
+                max_retry_delay_seconds=1.5,
+            ),
+            sleep=record_sleep,
+        )
+        work_item = await provider.retrieve_work_item("GMAI-17")
+
+    assert work_item.external_key == "GMAI-17"
+    assert delays == [1.0, 1.5]


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Load and validate an approved Jira Story or Task through the provider-neutral WorkManagementProvider contract.

* ### Task tickets:

    * Task ID: GMAI-17.
    * Relative task IDs:
        * [x] GMAI-16.
    * Relative PRs:
        * #45 (stacked contract dependency; merge this PR only after #45).

* ### Key point change (optional):

    * Parses Jira ADF descriptions and preserves explicit acceptance criteria.
    * Enforces the MVP 1 `spec-ready` label convention and supported Story/Task types.
    * Blocks missing acceptance criteria or repository metadata with actionable diagnostics.
    * Publishes readiness outcomes as Jira comments through guarded provider operations.
    * Maps authentication, authorization, visibility, rate-limit, transport, and validation failures without exposing credentials.
    * Validates Jira URL ports and maps HTTP client invalid-URL failures to the typed transport boundary.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [ ] 👮🏻‍♂️ Abstraction or base objects
        * [ ] 🤖 AI agent
        * [x] 📲 Info Provider
        * [ ] 🕸️ Web server
        * [ ] 📲 MCP client
        * [x] 🪡 API client
        * [ ] 🫀 Data model
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
        * [ ] 🧪 Smoke testing (with AI models real calling)
        * [x] 🧪 Contract testing
        * [ ] 🧪 Evaluation testing
    * [ ] 📚 Documentation
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
    The authenticated HTTP client is injected; this change does not store or log Jira credentials. Jira repository field IDs must be supplied explicitly.

## _Description_

* Added typed Jira adapter failures and bounded HTTP status mapping.
* Hardened configuration against mutable issue-type inputs, non-finite numeric bounds, booleans used as integers, invalid URL ports, and non-finite Retry-After values.
* Streams Jira response bodies, stops reading at the configured byte bound, and closes every success, error, and retry response.
* Added bounded ADF text and Acceptance Criteria parsing.
* Added Jira work-item retrieval, readiness validation, and Jira comment publishing.
* Verified ready, incomplete, unsupported, inaccessible, spec approval, bounded retry, unsafe key, invalid port, and invalid URL behavior.
* **Verification:** 36 adapter and contract test cases passed; targeted pre-commit, Ruff, and mypy passed. The main-based stacked diff may still inherit unrelated legacy lint failures pending its prerequisite PRs.