### PR TITLE
[GMAI-13] ✨ (workflow): Add the lightweight POC workflow runner.

### DIFF
--- a/docs/contents/document/work-run-lifecycle.mdx
+++ b/docs/contents/document/work-run-lifecycle.mdx
@@ -1,0 +1,56 @@
+---
+title: WorkRun lifecycle
+description: Domain states and transitions for one governed work execution.
+---
+
+# WorkRun lifecycle
+
+A `WorkRun` represents one approved Jira work item as it moves through governed
+execution. The model is immutable and independent of orchestration frameworks.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Approved
+    Approved --> Executing
+    Executing --> Verifying
+    Verifying --> Remediating
+    Remediating --> Executing
+    Remediating --> Verifying
+    Verifying --> PublishingDraftPR
+    PublishingDraftPR --> Completed
+
+    Approved --> Blocked
+    Approved --> Cancelled
+    Executing --> Failed
+    Executing --> Blocked
+    Executing --> Cancelled
+    Verifying --> Failed
+    Verifying --> Blocked
+    Verifying --> Cancelled
+    Remediating --> Failed
+    Remediating --> Blocked
+    Remediating --> Cancelled
+    PublishingDraftPR --> Failed
+    PublishingDraftPR --> Blocked
+    PublishingDraftPR --> Cancelled
+
+    Completed --> [*]
+    Failed --> [*]
+    Blocked --> [*]
+    Cancelled --> [*]
+```
+
+## Domain rules
+
+- `approved`, `executing`, `verifying`, `remediating`, and
+  `publishing_draft_pr` are active stages.
+- `completed`, `failed`, `blocked`, and `cancelled` are terminal outcomes. No
+  transition can leave a terminal outcome.
+- Completion is only valid after Draft PR publication and requires a correlated
+  HTTPS pull-request URL.
+- A remediation pass may return to execution when code changes are needed or
+  directly to verification when only verification inputs changed.
+- Identity, Jira issue, repository, branch, Agent Assembly correlation, artifact,
+  and event references survive every transition.
+- Reference URLs reject embedded credentials so persisted domain data cannot
+  accidentally retain URL-based secrets.

--- a/gearmeshing_ai/application/workflow_runner.py
+++ b/gearmeshing_ai/application/workflow_runner.py
@@ -29,6 +29,16 @@ WORKFLOW_STAGE_ORDER = (
     WorkflowStage.FINISH,
 )
 
+_WORKFLOW_STATE_AFTER_PREFIX = (
+    WorkRunState.APPROVED,
+    WorkRunState.EXECUTING,
+    WorkRunState.VERIFYING,
+    WorkRunState.REMEDIATING,
+    WorkRunState.VERIFYING,
+    WorkRunState.PUBLISHING_DRAFT_PR,
+    WorkRunState.COMPLETED,
+)
+
 
 class WorkflowFailureKind(StrEnum):
     """Stable classifications suitable for policy and retry decisions."""
@@ -130,8 +140,33 @@ class WorkflowCheckpoint:
         if self.completed_stages != expected_prefix:
             message = "completed_stages must be a canonical workflow prefix"
             raise ValueError(message)
-        if self.failure is not None and not self.work_run.state.is_terminal:
-            message = "a failed checkpoint must contain a terminal WorkRun"
+        if self.failure is None:
+            self._validate_active_progress()
+        else:
+            self._validate_failed_progress()
+
+    def _validate_active_progress(self) -> None:
+        expected_state = _WORKFLOW_STATE_AFTER_PREFIX[len(self.completed_stages)]
+        if self.work_run.state is not expected_state:
+            message = "WorkRun state does not match completed workflow stages"
+            raise ValueError(message)
+        if expected_state is WorkRunState.COMPLETED and self.work_run.correlation.pull_request_url is None:
+            message = "a completed workflow checkpoint must reference its Draft PR"
+            raise ValueError(message)
+
+    def _validate_failed_progress(self) -> None:
+        if len(self.completed_stages) == len(WORKFLOW_STAGE_ORDER):
+            message = "a completed workflow checkpoint cannot contain a failure"
+            raise ValueError(message)
+        expected_failed_stage = WORKFLOW_STAGE_ORDER[len(self.completed_stages)]
+        if self.failure is None or self.failure.stage is not expected_failed_stage:
+            message = "failure stage must immediately follow completed workflow stages"
+            raise ValueError(message)
+        expected_terminal_state = (
+            WorkRunState.BLOCKED if expected_failed_stage is WorkflowStage.INGEST else WorkRunState.FAILED
+        )
+        if self.work_run.state is not expected_terminal_state:
+            message = "failed workflow checkpoint has an invalid terminal WorkRun state"
             raise ValueError(message)
 
 

--- a/gearmeshing_ai/application/workflow_runner.py
+++ b/gearmeshing_ai/application/workflow_runner.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Protocol
 
-from gearmeshing_ai.domain.work_run import WorkRun
+from gearmeshing_ai.domain.work_run import WorkRun, WorkRunState
 
 _MAX_REASON_CODE_LENGTH = 64
 
@@ -133,3 +133,101 @@ class WorkflowCheckpoint:
         if self.failure is not None and not self.work_run.state.is_terminal:
             message = "a failed checkpoint must contain a terminal WorkRun"
             raise ValueError(message)
+
+
+_STAGE_TARGET_STATES = {
+    WorkflowStage.INGEST: WorkRunState.EXECUTING,
+    WorkflowStage.EXECUTE: WorkRunState.VERIFYING,
+    WorkflowStage.VERIFY: WorkRunState.REMEDIATING,
+    WorkflowStage.REMEDIATE: WorkRunState.VERIFYING,
+    WorkflowStage.PUBLISH: WorkRunState.PUBLISHING_DRAFT_PR,
+    WorkflowStage.FINISH: WorkRunState.COMPLETED,
+}
+
+
+class WorkflowRunner:
+    """Run the fixed MVP workflow sequentially with replay-safe boundaries."""
+
+    def __init__(self, actions: WorkflowActions) -> None:
+        self._actions = actions
+
+    def run(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+        """Run remaining stages until completion or the first failure."""
+        current = checkpoint
+        for stage in WORKFLOW_STAGE_ORDER:
+            current = self.run_stage(current, stage)
+            if current.failure is not None:
+                break
+        return current
+
+    def run_stage(
+        self,
+        checkpoint: WorkflowCheckpoint,
+        stage: WorkflowStage,
+    ) -> WorkflowCheckpoint:
+        """Run one stage, skipping it when its checkpoint already exists."""
+        if stage in checkpoint.completed_stages or checkpoint.failure is not None:
+            return checkpoint
+
+        expected_stage = WORKFLOW_STAGE_ORDER[len(checkpoint.completed_stages)]
+        if stage is not expected_stage:
+            message = f"expected {expected_stage.value} stage, received {stage.value}"
+            raise ValueError(message)
+
+        work_run = checkpoint.work_run
+        target_state = _STAGE_TARGET_STATES[stage]
+        work_run.transition_to(target_state)
+        context = StageContext(
+            stage=stage,
+            idempotency_key=f"{work_run.identity.run_id}:{stage.value}",
+        )
+
+        try:
+            updated_work_run = self._actions.for_stage(stage)(work_run, context)
+            self._validate_action_result(work_run, updated_work_run)
+            transitioned_work_run = updated_work_run.transition_to(target_state)
+        except WorkflowStageError as error:
+            return self._failed_checkpoint(checkpoint, stage, error.kind, error.reason_code)
+        except Exception:
+            return self._failed_checkpoint(
+                checkpoint,
+                stage,
+                WorkflowFailureKind.INTERNAL,
+                "unexpected_error",
+            )
+
+        return WorkflowCheckpoint(
+            work_run=transitioned_work_run,
+            completed_stages=(*checkpoint.completed_stages, stage),
+        )
+
+    @staticmethod
+    def _validate_action_result(original: WorkRun, updated: WorkRun) -> None:
+        if not isinstance(updated, WorkRun):
+            message = "stage action must return a WorkRun"
+            raise TypeError(message)
+        if updated.identity != original.identity:
+            message = "stage action must preserve WorkRun identity"
+            raise ValueError(message)
+        if updated.state is not original.state:
+            message = "stage action must not change WorkRun state"
+            raise ValueError(message)
+
+    @staticmethod
+    def _failed_checkpoint(
+        checkpoint: WorkflowCheckpoint,
+        stage: WorkflowStage,
+        kind: WorkflowFailureKind,
+        reason_code: str,
+    ) -> WorkflowCheckpoint:
+        terminal_state = (
+            WorkRunState.BLOCKED
+            if checkpoint.work_run.state is WorkRunState.APPROVED
+            else WorkRunState.FAILED
+        )
+        failed_work_run = checkpoint.work_run.transition_to(terminal_state)
+        return WorkflowCheckpoint(
+            work_run=failed_work_run,
+            completed_stages=checkpoint.completed_stages,
+            failure=StageFailure(stage=stage, kind=kind, reason_code=reason_code),
+        )

--- a/gearmeshing_ai/application/workflow_runner.py
+++ b/gearmeshing_ai/application/workflow_runner.py
@@ -1,0 +1,135 @@
+"""Deterministic application runner for the governed MVP workflow."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+from gearmeshing_ai.domain.work_run import WorkRun
+
+_MAX_REASON_CODE_LENGTH = 64
+
+
+class WorkflowStage(StrEnum):
+    """Ordered stages in the lightweight proof-of-concept workflow."""
+
+    INGEST = "ingest"
+    EXECUTE = "execute"
+    VERIFY = "verify"
+    REMEDIATE = "remediate"
+    PUBLISH = "publish"
+    FINISH = "finish"
+
+
+WORKFLOW_STAGE_ORDER = (
+    WorkflowStage.INGEST,
+    WorkflowStage.EXECUTE,
+    WorkflowStage.VERIFY,
+    WorkflowStage.REMEDIATE,
+    WorkflowStage.PUBLISH,
+    WorkflowStage.FINISH,
+)
+
+
+class WorkflowFailureKind(StrEnum):
+    """Stable classifications suitable for policy and retry decisions."""
+
+    INVALID_INPUT = "invalid_input"
+    POLICY = "policy"
+    TRANSIENT = "transient"
+    INTERNAL = "internal"
+
+
+def _validate_reason_code(reason_code: str) -> str:
+    normalized = reason_code.strip().lower()
+    if not normalized or len(normalized) > _MAX_REASON_CODE_LENGTH:
+        message = f"reason_code must be between 1 and {_MAX_REASON_CODE_LENGTH} characters"
+        raise ValueError(message)
+    if any(not (character.isalnum() or character in {"-", "_"}) for character in normalized):
+        message = "reason_code must contain only letters, numbers, hyphens, or underscores"
+        raise ValueError(message)
+    return normalized
+
+
+class WorkflowStageError(RuntimeError):
+    """A stage failure with a safe, bounded machine-readable reason."""
+
+    def __init__(self, kind: WorkflowFailureKind, reason_code: str) -> None:
+        if not isinstance(kind, WorkflowFailureKind):
+            message = "kind must be a WorkflowFailureKind"
+            raise TypeError(message)
+        self.kind = kind
+        self.reason_code = _validate_reason_code(reason_code)
+        super().__init__(self.reason_code)
+
+
+@dataclass(frozen=True, slots=True)
+class StageContext:
+    """Stable stage metadata for adapter-level idempotency keys."""
+
+    stage: WorkflowStage
+    idempotency_key: str
+
+
+class StageAction(Protocol):
+    """Framework-neutral boundary implemented by workflow stage adapters."""
+
+    def __call__(self, work_run: WorkRun, context: StageContext) -> WorkRun:
+        """Perform a stage and return the updated WorkRun."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowActions:
+    """Explicit action dependencies for every workflow stage."""
+
+    ingest: StageAction
+    execute: StageAction
+    verify: StageAction
+    remediate: StageAction
+    publish: StageAction
+    finish: StageAction
+
+    def for_stage(self, stage: WorkflowStage) -> StageAction:
+        """Return the action configured for ``stage``."""
+        actions: dict[WorkflowStage, StageAction] = {
+            WorkflowStage.INGEST: self.ingest,
+            WorkflowStage.EXECUTE: self.execute,
+            WorkflowStage.VERIFY: self.verify,
+            WorkflowStage.REMEDIATE: self.remediate,
+            WorkflowStage.PUBLISH: self.publish,
+            WorkflowStage.FINISH: self.finish,
+        }
+        return actions[stage]
+
+
+@dataclass(frozen=True, slots=True)
+class StageFailure:
+    """Non-sensitive failure record captured at a stage boundary."""
+
+    stage: WorkflowStage
+    kind: WorkflowFailureKind
+    reason_code: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "reason_code", _validate_reason_code(self.reason_code))
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCheckpoint:
+    """Replayable workflow progress returned after each stage boundary."""
+
+    work_run: WorkRun
+    completed_stages: tuple[WorkflowStage, ...] = ()
+    failure: StageFailure | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.work_run, WorkRun):
+            message = "work_run must be a WorkRun"
+            raise TypeError(message)
+        expected_prefix = WORKFLOW_STAGE_ORDER[: len(self.completed_stages)]
+        if self.completed_stages != expected_prefix:
+            message = "completed_stages must be a canonical workflow prefix"
+            raise ValueError(message)
+        if self.failure is not None and not self.work_run.state.is_terminal:
+            message = "a failed checkpoint must contain a terminal WorkRun"
+            raise ValueError(message)

--- a/gearmeshing_ai/application/workflow_runner.py
+++ b/gearmeshing_ai/application/workflow_runner.py
@@ -219,7 +219,7 @@ class WorkflowRunner:
 
         try:
             updated_work_run = self._actions.for_stage(stage)(work_run, context)
-            self._validate_action_result(work_run, updated_work_run)
+            self._validate_action_result(work_run, updated_work_run, stage)
             transitioned_work_run = updated_work_run.transition_to(target_state)
         except WorkflowStageError as error:
             return self._failed_checkpoint(checkpoint, stage, error.kind, error.reason_code)
@@ -237,7 +237,11 @@ class WorkflowRunner:
         )
 
     @staticmethod
-    def _validate_action_result(original: WorkRun, updated: WorkRun) -> None:
+    def _validate_action_result(
+        original: WorkRun,
+        updated: WorkRun,
+        stage: WorkflowStage,
+    ) -> None:
         if not isinstance(updated, WorkRun):
             message = "stage action must return a WorkRun"
             raise TypeError(message)
@@ -246,6 +250,46 @@ class WorkflowRunner:
             raise ValueError(message)
         if updated.state is not original.state:
             message = "stage action must not change WorkRun state"
+            raise ValueError(message)
+        original_stable_correlation = (
+            original.correlation.jira_issue_key,
+            original.correlation.repository,
+            original.correlation.branch,
+            original.correlation.agent_assembly_correlation_id,
+        )
+        updated_stable_correlation = (
+            updated.correlation.jira_issue_key,
+            updated.correlation.repository,
+            updated.correlation.branch,
+            updated.correlation.agent_assembly_correlation_id,
+        )
+        if updated_stable_correlation != original_stable_correlation:
+            message = "stage action must preserve stable WorkRun correlation"
+            raise ValueError(message)
+
+        original_pull_request = original.correlation.pull_request_url
+        updated_pull_request = updated.correlation.pull_request_url
+        if stage is not WorkflowStage.PUBLISH and updated_pull_request != original_pull_request:
+            message = "only the publish stage may associate a Draft PR"
+            raise ValueError(message)
+        if (
+            stage is WorkflowStage.PUBLISH
+            and original_pull_request is not None
+            and updated_pull_request != original_pull_request
+        ):
+            message = "the publish stage must not overwrite an existing Draft PR"
+            raise ValueError(message)
+        if stage is WorkflowStage.PUBLISH and updated_pull_request is None:
+            message = "the publish stage must associate a Draft PR"
+            raise ValueError(message)
+
+        artifact_count = len(original.artifact_references)
+        if updated.artifact_references[:artifact_count] != original.artifact_references:
+            message = "stage action must preserve existing artifact evidence"
+            raise ValueError(message)
+        event_count = len(original.event_references)
+        if updated.event_references[:event_count] != original.event_references:
+            message = "stage action must preserve existing event evidence"
             raise ValueError(message)
 
     @staticmethod

--- a/gearmeshing_ai/application/workflow_runner.py
+++ b/gearmeshing_ai/application/workflow_runner.py
@@ -221,9 +221,7 @@ class WorkflowRunner:
         reason_code: str,
     ) -> WorkflowCheckpoint:
         terminal_state = (
-            WorkRunState.BLOCKED
-            if checkpoint.work_run.state is WorkRunState.APPROVED
-            else WorkRunState.FAILED
+            WorkRunState.BLOCKED if checkpoint.work_run.state is WorkRunState.APPROVED else WorkRunState.FAILED
         )
         failed_work_run = checkpoint.work_run.transition_to(terminal_state)
         return WorkflowCheckpoint(

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -1,0 +1,84 @@
+"""Framework-independent domain model for governed work execution."""
+
+from enum import StrEnum
+
+
+class InvalidWorkRunTransition(ValueError):
+    """Raised when a WorkRun lifecycle transition violates domain rules."""
+
+
+class WorkRunState(StrEnum):
+    """Execution stages and terminal outcomes for a WorkRun."""
+
+    APPROVED = "approved"
+    EXECUTING = "executing"
+    VERIFYING = "verifying"
+    REMEDIATING = "remediating"
+    PUBLISHING_DRAFT_PR = "publishing_draft_pr"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+    CANCELLED = "cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return whether the state represents a final WorkRun outcome."""
+        return self in TERMINAL_WORK_RUN_STATES
+
+
+TERMINAL_WORK_RUN_STATES = frozenset(
+    {
+        WorkRunState.COMPLETED,
+        WorkRunState.FAILED,
+        WorkRunState.BLOCKED,
+        WorkRunState.CANCELLED,
+    }
+)
+
+VALID_WORK_RUN_TRANSITIONS: dict[WorkRunState, frozenset[WorkRunState]] = {
+    WorkRunState.APPROVED: frozenset(
+        {
+            WorkRunState.EXECUTING,
+            WorkRunState.BLOCKED,
+            WorkRunState.CANCELLED,
+        }
+    ),
+    WorkRunState.EXECUTING: frozenset(
+        {
+            WorkRunState.VERIFYING,
+            WorkRunState.FAILED,
+            WorkRunState.BLOCKED,
+            WorkRunState.CANCELLED,
+        }
+    ),
+    WorkRunState.VERIFYING: frozenset(
+        {
+            WorkRunState.REMEDIATING,
+            WorkRunState.PUBLISHING_DRAFT_PR,
+            WorkRunState.FAILED,
+            WorkRunState.BLOCKED,
+            WorkRunState.CANCELLED,
+        }
+    ),
+    WorkRunState.REMEDIATING: frozenset(
+        {
+            WorkRunState.EXECUTING,
+            WorkRunState.VERIFYING,
+            WorkRunState.FAILED,
+            WorkRunState.BLOCKED,
+            WorkRunState.CANCELLED,
+        }
+    ),
+    WorkRunState.PUBLISHING_DRAFT_PR: frozenset(
+        {
+            WorkRunState.COMPLETED,
+            WorkRunState.FAILED,
+            WorkRunState.BLOCKED,
+            WorkRunState.CANCELLED,
+        }
+    ),
+    WorkRunState.COMPLETED: frozenset(),
+    WorkRunState.FAILED: frozenset(),
+    WorkRunState.BLOCKED: frozenset(),
+    WorkRunState.CANCELLED: frozenset(),
+}

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -144,6 +144,14 @@ class WorkRun:
             raise TypeError("identity must be a WorkRunIdentity")
         if not isinstance(self.state, WorkRunState):
             raise TypeError("state must be a WorkRunState")
+        if not isinstance(self.artifact_references, tuple) or any(
+            not isinstance(reference, ArtifactReference) for reference in self.artifact_references
+        ):
+            raise TypeError("artifact_references must contain only ArtifactReference values")
+        if not isinstance(self.event_references, tuple) or any(
+            not isinstance(reference, EventReference) for reference in self.event_references
+        ):
+            raise TypeError("event_references must contain only EventReference values")
 
     def transition_to(self, target: WorkRunState) -> "WorkRun":
         """Return a new WorkRun in ``target`` when the transition is valid."""

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -160,6 +160,14 @@ class WorkRun:
         correlation = replace(self.correlation, pull_request_url=pull_request_url)
         return replace(self, correlation=correlation)
 
+    def with_artifact_reference(self, reference: ArtifactReference) -> "WorkRun":
+        """Return a new WorkRun containing one additional artifact reference."""
+        if not isinstance(reference, ArtifactReference):
+            raise TypeError("reference must be an ArtifactReference")
+        if reference in self.artifact_references:
+            return self
+        return replace(self, artifact_references=(*self.artifact_references, reference))
+
 
 class InvalidWorkRunTransition(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -127,64 +127,6 @@ class WorkRunIdentity:
             raise TypeError("run_id must be a UUID")
 
 
-@dataclass(frozen=True, slots=True)
-class WorkRun:
-    """Immutable aggregate describing one governed work execution."""
-
-    correlation: WorkRunCorrelation
-    identity: WorkRunIdentity = field(default_factory=WorkRunIdentity.new)
-    state: WorkRunState = WorkRunState.APPROVED
-    artifact_references: tuple[ArtifactReference, ...] = ()
-    event_references: tuple[EventReference, ...] = ()
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.correlation, WorkRunCorrelation):
-            raise TypeError("correlation must be a WorkRunCorrelation")
-        if not isinstance(self.identity, WorkRunIdentity):
-            raise TypeError("identity must be a WorkRunIdentity")
-        if not isinstance(self.state, WorkRunState):
-            raise TypeError("state must be a WorkRunState")
-        if not isinstance(self.artifact_references, tuple) or any(
-            not isinstance(reference, ArtifactReference) for reference in self.artifact_references
-        ):
-            raise TypeError("artifact_references must contain only ArtifactReference values")
-        if not isinstance(self.event_references, tuple) or any(
-            not isinstance(reference, EventReference) for reference in self.event_references
-        ):
-            raise TypeError("event_references must contain only EventReference values")
-
-    def transition_to(self, target: WorkRunState) -> "WorkRun":
-        """Return a new WorkRun in ``target`` when the transition is valid."""
-        if not isinstance(target, WorkRunState):
-            raise TypeError("target must be a WorkRunState")
-        if target not in VALID_WORK_RUN_TRANSITIONS[self.state]:
-            raise InvalidWorkRunTransition(f"cannot transition from {self.state} to {target}")
-        if target is WorkRunState.COMPLETED and self.correlation.pull_request_url is None:
-            raise InvalidWorkRunTransition("a completed WorkRun must reference its Draft PR")
-        return replace(self, state=target)
-
-    def associate_pull_request(self, pull_request_url: str) -> "WorkRun":
-        """Return a new WorkRun correlated with its Draft pull request."""
-        correlation = replace(self.correlation, pull_request_url=pull_request_url)
-        return replace(self, correlation=correlation)
-
-    def with_artifact_reference(self, reference: ArtifactReference) -> "WorkRun":
-        """Return a new WorkRun containing one additional artifact reference."""
-        if not isinstance(reference, ArtifactReference):
-            raise TypeError("reference must be an ArtifactReference")
-        if reference in self.artifact_references:
-            return self
-        return replace(self, artifact_references=(*self.artifact_references, reference))
-
-    def with_event_reference(self, reference: EventReference) -> "WorkRun":
-        """Return a new WorkRun containing one additional event reference."""
-        if not isinstance(reference, EventReference):
-            raise TypeError("reference must be an EventReference")
-        if reference in self.event_references:
-            return self
-        return replace(self, event_references=(*self.event_references, reference))
-
-
 class InvalidWorkRunTransition(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""
 
@@ -264,3 +206,61 @@ VALID_WORK_RUN_TRANSITIONS: dict[WorkRunState, frozenset[WorkRunState]] = {
     WorkRunState.BLOCKED: frozenset(),
     WorkRunState.CANCELLED: frozenset(),
 }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkRun:
+    """Immutable aggregate describing one governed work execution."""
+
+    correlation: WorkRunCorrelation
+    identity: WorkRunIdentity = field(default_factory=WorkRunIdentity.new)
+    state: WorkRunState = WorkRunState.APPROVED
+    artifact_references: tuple[ArtifactReference, ...] = ()
+    event_references: tuple[EventReference, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.correlation, WorkRunCorrelation):
+            raise TypeError("correlation must be a WorkRunCorrelation")
+        if not isinstance(self.identity, WorkRunIdentity):
+            raise TypeError("identity must be a WorkRunIdentity")
+        if not isinstance(self.state, WorkRunState):
+            raise TypeError("state must be a WorkRunState")
+        if not isinstance(self.artifact_references, tuple) or any(
+            not isinstance(reference, ArtifactReference) for reference in self.artifact_references
+        ):
+            raise TypeError("artifact_references must contain only ArtifactReference values")
+        if not isinstance(self.event_references, tuple) or any(
+            not isinstance(reference, EventReference) for reference in self.event_references
+        ):
+            raise TypeError("event_references must contain only EventReference values")
+
+    def transition_to(self, target: WorkRunState) -> "WorkRun":
+        """Return a new WorkRun in ``target`` when the transition is valid."""
+        if not isinstance(target, WorkRunState):
+            raise TypeError("target must be a WorkRunState")
+        if target not in VALID_WORK_RUN_TRANSITIONS[self.state]:
+            raise InvalidWorkRunTransition(f"cannot transition from {self.state} to {target}")
+        if target is WorkRunState.COMPLETED and self.correlation.pull_request_url is None:
+            raise InvalidWorkRunTransition("a completed WorkRun must reference its Draft PR")
+        return replace(self, state=target)
+
+    def associate_pull_request(self, pull_request_url: str) -> "WorkRun":
+        """Return a new WorkRun correlated with its Draft pull request."""
+        correlation = replace(self.correlation, pull_request_url=pull_request_url)
+        return replace(self, correlation=correlation)
+
+    def with_artifact_reference(self, reference: ArtifactReference) -> "WorkRun":
+        """Return a new WorkRun containing one additional artifact reference."""
+        if not isinstance(reference, ArtifactReference):
+            raise TypeError("reference must be an ArtifactReference")
+        if reference in self.artifact_references:
+            return self
+        return replace(self, artifact_references=(*self.artifact_references, reference))
+
+    def with_event_reference(self, reference: EventReference) -> "WorkRun":
+        """Return a new WorkRun containing one additional event reference."""
+        if not isinstance(reference, EventReference):
+            raise TypeError("reference must be an EventReference")
+        if reference in self.event_references:
+            return self
+        return replace(self, event_references=(*self.event_references, reference))

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -1,11 +1,10 @@
 """Framework-independent domain model for governed work execution."""
 
+import re
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
-import re
 from urllib.parse import urlsplit
 from uuid import UUID, uuid4
-
 
 _MAX_IDENTIFIER_LENGTH = 255
 _MAX_URI_LENGTH = 2048

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import re
 from urllib.parse import urlsplit
+from uuid import UUID, uuid4
 
 
 _MAX_IDENTIFIER_LENGTH = 255
@@ -108,6 +109,22 @@ class WorkRunCorrelation:
                 "pull_request_url",
                 _require_https_url(self.pull_request_url, "pull_request_url"),
             )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkRunIdentity:
+    """Stable internal identity for one WorkRun."""
+
+    run_id: UUID
+
+    @classmethod
+    def new(cls) -> "WorkRunIdentity":
+        """Create a WorkRun identity using a random, non-semantic identifier."""
+        return cls(run_id=uuid4())
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_id, UUID):
+            raise TypeError("run_id must be a UUID")
 
 
 class InvalidWorkRunTransition(ValueError):

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -1,6 +1,6 @@
 """Framework-independent domain model for governed work execution."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 import re
 from urllib.parse import urlsplit
@@ -144,6 +144,16 @@ class WorkRun:
             raise TypeError("identity must be a WorkRunIdentity")
         if not isinstance(self.state, WorkRunState):
             raise TypeError("state must be a WorkRunState")
+
+    def transition_to(self, target: WorkRunState) -> "WorkRun":
+        """Return a new WorkRun in ``target`` when the transition is valid."""
+        if not isinstance(target, WorkRunState):
+            raise TypeError("target must be a WorkRunState")
+        if target not in VALID_WORK_RUN_TRANSITIONS[self.state]:
+            raise InvalidWorkRunTransition(f"cannot transition from {self.state} to {target}")
+        if target is WorkRunState.COMPLETED and self.correlation.pull_request_url is None:
+            raise InvalidWorkRunTransition("a completed WorkRun must reference its Draft PR")
+        return replace(self, state=target)
 
 
 class InvalidWorkRunTransition(ValueError):

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -49,6 +49,18 @@ class ArtifactReference:
         object.__setattr__(self, "uri", _require_safe_uri(self.uri, "uri"))
 
 
+@dataclass(frozen=True, slots=True)
+class EventReference:
+    """Stable identifier for an event associated with a WorkRun."""
+
+    event_id: str
+    event_type: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "event_id", _require_bounded_text(self.event_id, "event_id"))
+        object.__setattr__(self, "event_type", _require_bounded_text(self.event_type, "event_type"))
+
+
 class InvalidWorkRunTransition(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""
 

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -2,11 +2,13 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
+import re
 from urllib.parse import urlsplit
 
 
 _MAX_IDENTIFIER_LENGTH = 255
 _MAX_URI_LENGTH = 2048
+_JIRA_ISSUE_KEY_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*-[1-9][0-9]*$")
 
 
 def _require_bounded_text(value: str, field_name: str) -> str:
@@ -32,6 +34,23 @@ def _require_safe_uri(value: str, field_name: str) -> str:
         raise ValueError(f"{field_name} must be an absolute URI")
     if parsed.username is not None or parsed.password is not None:
         raise ValueError(f"{field_name} must not contain credentials")
+    return normalized
+
+
+def _require_jira_issue_key(value: str) -> str:
+    """Validate a canonical Jira issue key."""
+    normalized = value.strip().upper()
+    if not _JIRA_ISSUE_KEY_PATTERN.fullmatch(normalized):
+        raise ValueError("jira_issue_key must use the PROJECT-123 format")
+    return normalized
+
+
+def _require_https_url(value: str, field_name: str) -> str:
+    """Validate an HTTPS URL suitable for cross-system correlation."""
+    normalized = _require_safe_uri(value, field_name)
+    parsed = urlsplit(normalized)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise ValueError(f"{field_name} must be an HTTPS URL")
     return normalized
 
 

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -1,6 +1,6 @@
 """Framework-independent domain model for governed work execution."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 import re
 from urllib.parse import urlsplit
@@ -125,6 +125,25 @@ class WorkRunIdentity:
     def __post_init__(self) -> None:
         if not isinstance(self.run_id, UUID):
             raise TypeError("run_id must be a UUID")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkRun:
+    """Immutable aggregate describing one governed work execution."""
+
+    correlation: WorkRunCorrelation
+    identity: WorkRunIdentity = field(default_factory=WorkRunIdentity.new)
+    state: WorkRunState = WorkRunState.APPROVED
+    artifact_references: tuple[ArtifactReference, ...] = ()
+    event_references: tuple[EventReference, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.correlation, WorkRunCorrelation):
+            raise TypeError("correlation must be a WorkRunCorrelation")
+        if not isinstance(self.identity, WorkRunIdentity):
+            raise TypeError("identity must be a WorkRunIdentity")
+        if not isinstance(self.state, WorkRunState):
+            raise TypeError("state must be a WorkRunState")
 
 
 class InvalidWorkRunTransition(ValueError):

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -168,6 +168,14 @@ class WorkRun:
             return self
         return replace(self, artifact_references=(*self.artifact_references, reference))
 
+    def with_event_reference(self, reference: EventReference) -> "WorkRun":
+        """Return a new WorkRun containing one additional event reference."""
+        if not isinstance(reference, EventReference):
+            raise TypeError("reference must be an EventReference")
+        if reference in self.event_references:
+            return self
+        return replace(self, event_references=(*self.event_references, reference))
+
 
 class InvalidWorkRunTransition(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -127,7 +127,7 @@ class WorkRunIdentity:
             raise TypeError("run_id must be a UUID")
 
 
-class InvalidWorkRunTransition(ValueError):
+class InvalidWorkRunTransitionError(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""
 
 
@@ -239,9 +239,9 @@ class WorkRun:
         if not isinstance(target, WorkRunState):
             raise TypeError("target must be a WorkRunState")
         if target not in VALID_WORK_RUN_TRANSITIONS[self.state]:
-            raise InvalidWorkRunTransition(f"cannot transition from {self.state} to {target}")
+            raise InvalidWorkRunTransitionError(f"cannot transition from {self.state} to {target}")
         if target is WorkRunState.COMPLETED and self.correlation.pull_request_url is None:
-            raise InvalidWorkRunTransition("a completed WorkRun must reference its Draft PR")
+            raise InvalidWorkRunTransitionError("a completed WorkRun must reference its Draft PR")
         return replace(self, state=target)
 
     def associate_pull_request(self, pull_request_url: str) -> "WorkRun":

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -155,6 +155,11 @@ class WorkRun:
             raise InvalidWorkRunTransition("a completed WorkRun must reference its Draft PR")
         return replace(self, state=target)
 
+    def associate_pull_request(self, pull_request_url: str) -> "WorkRun":
+        """Return a new WorkRun correlated with its Draft pull request."""
+        correlation = replace(self.correlation, pull_request_url=pull_request_url)
+        return replace(self, correlation=correlation)
+
 
 class InvalidWorkRunTransition(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -16,11 +16,14 @@ def _require_bounded_text(value: str, field_name: str) -> str:
     """Validate and normalize a bounded, non-sensitive identifier."""
     normalized = value.strip()
     if not normalized:
-        raise ValueError(f"{field_name} must not be empty")
+        message = f"{field_name} must not be empty"
+        raise ValueError(message)
     if len(normalized) > _MAX_IDENTIFIER_LENGTH:
-        raise ValueError(f"{field_name} must not exceed {_MAX_IDENTIFIER_LENGTH} characters")
+        message = f"{field_name} must not exceed {_MAX_IDENTIFIER_LENGTH} characters"
+        raise ValueError(message)
     if any(character.isspace() or ord(character) < 32 for character in normalized):
-        raise ValueError(f"{field_name} must not contain whitespace or control characters")
+        message = f"{field_name} must not contain whitespace or control characters"
+        raise ValueError(message)
     return normalized
 
 
@@ -28,13 +31,16 @@ def _require_safe_uri(value: str, field_name: str) -> str:
     """Validate a URI without accepting embedded credentials."""
     normalized = value.strip()
     if not normalized or len(normalized) > _MAX_URI_LENGTH:
-        raise ValueError(f"{field_name} must be between 1 and {_MAX_URI_LENGTH} characters")
+        message = f"{field_name} must be between 1 and {_MAX_URI_LENGTH} characters"
+        raise ValueError(message)
 
     parsed = urlsplit(normalized)
     if not parsed.scheme:
-        raise ValueError(f"{field_name} must be an absolute URI")
+        message = f"{field_name} must be an absolute URI"
+        raise ValueError(message)
     if parsed.username is not None or parsed.password is not None:
-        raise ValueError(f"{field_name} must not contain credentials")
+        message = f"{field_name} must not contain credentials"
+        raise ValueError(message)
     return normalized
 
 
@@ -42,7 +48,8 @@ def _require_jira_issue_key(value: str) -> str:
     """Validate a canonical Jira issue key."""
     normalized = value.strip().upper()
     if not _JIRA_ISSUE_KEY_PATTERN.fullmatch(normalized):
-        raise ValueError("jira_issue_key must use the PROJECT-123 format")
+        message = "jira_issue_key must use the PROJECT-123 format"
+        raise ValueError(message)
     return normalized
 
 
@@ -51,7 +58,8 @@ def _require_https_url(value: str, field_name: str) -> str:
     normalized = _require_safe_uri(value, field_name)
     parsed = urlsplit(normalized)
     if parsed.scheme != "https" or not parsed.hostname:
-        raise ValueError(f"{field_name} must be an HTTPS URL")
+        message = f"{field_name} must be an HTTPS URL"
+        raise ValueError(message)
     return normalized
 
 
@@ -124,7 +132,8 @@ class WorkRunIdentity:
 
     def __post_init__(self) -> None:
         if not isinstance(self.run_id, UUID):
-            raise TypeError("run_id must be a UUID")
+            message = "run_id must be a UUID"
+            raise TypeError(message)
 
 
 class InvalidWorkRunTransitionError(ValueError):
@@ -220,28 +229,36 @@ class WorkRun:
 
     def __post_init__(self) -> None:
         if not isinstance(self.correlation, WorkRunCorrelation):
-            raise TypeError("correlation must be a WorkRunCorrelation")
+            message = "correlation must be a WorkRunCorrelation"
+            raise TypeError(message)
         if not isinstance(self.identity, WorkRunIdentity):
-            raise TypeError("identity must be a WorkRunIdentity")
+            message = "identity must be a WorkRunIdentity"
+            raise TypeError(message)
         if not isinstance(self.state, WorkRunState):
-            raise TypeError("state must be a WorkRunState")
+            message = "state must be a WorkRunState"
+            raise TypeError(message)
         if not isinstance(self.artifact_references, tuple) or any(
             not isinstance(reference, ArtifactReference) for reference in self.artifact_references
         ):
-            raise TypeError("artifact_references must contain only ArtifactReference values")
+            message = "artifact_references must contain only ArtifactReference values"
+            raise TypeError(message)
         if not isinstance(self.event_references, tuple) or any(
             not isinstance(reference, EventReference) for reference in self.event_references
         ):
-            raise TypeError("event_references must contain only EventReference values")
+            message = "event_references must contain only EventReference values"
+            raise TypeError(message)
 
     def transition_to(self, target: WorkRunState) -> "WorkRun":
         """Return a new WorkRun in ``target`` when the transition is valid."""
         if not isinstance(target, WorkRunState):
-            raise TypeError("target must be a WorkRunState")
+            message = "target must be a WorkRunState"
+            raise TypeError(message)
         if target not in VALID_WORK_RUN_TRANSITIONS[self.state]:
-            raise InvalidWorkRunTransitionError(f"cannot transition from {self.state} to {target}")
+            message = f"cannot transition from {self.state} to {target}"
+            raise InvalidWorkRunTransitionError(message)
         if target is WorkRunState.COMPLETED and self.correlation.pull_request_url is None:
-            raise InvalidWorkRunTransitionError("a completed WorkRun must reference its Draft PR")
+            message = "a completed WorkRun must reference its Draft PR"
+            raise InvalidWorkRunTransitionError(message)
         return replace(self, state=target)
 
     def associate_pull_request(self, pull_request_url: str) -> "WorkRun":
@@ -252,7 +269,8 @@ class WorkRun:
     def with_artifact_reference(self, reference: ArtifactReference) -> "WorkRun":
         """Return a new WorkRun containing one additional artifact reference."""
         if not isinstance(reference, ArtifactReference):
-            raise TypeError("reference must be an ArtifactReference")
+            message = "reference must be an ArtifactReference"
+            raise TypeError(message)
         if reference in self.artifact_references:
             return self
         return replace(self, artifact_references=(*self.artifact_references, reference))
@@ -260,7 +278,8 @@ class WorkRun:
     def with_event_reference(self, reference: EventReference) -> "WorkRun":
         """Return a new WorkRun containing one additional event reference."""
         if not isinstance(reference, EventReference):
-            raise TypeError("reference must be an EventReference")
+            message = "reference must be an EventReference"
+            raise TypeError(message)
         if reference in self.event_references:
             return self
         return replace(self, event_references=(*self.event_references, reference))

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -1,6 +1,37 @@
 """Framework-independent domain model for governed work execution."""
 
 from enum import StrEnum
+from urllib.parse import urlsplit
+
+
+_MAX_IDENTIFIER_LENGTH = 255
+_MAX_URI_LENGTH = 2048
+
+
+def _require_bounded_text(value: str, field_name: str) -> str:
+    """Validate and normalize a bounded, non-sensitive identifier."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be empty")
+    if len(normalized) > _MAX_IDENTIFIER_LENGTH:
+        raise ValueError(f"{field_name} must not exceed {_MAX_IDENTIFIER_LENGTH} characters")
+    if any(character.isspace() or ord(character) < 32 for character in normalized):
+        raise ValueError(f"{field_name} must not contain whitespace or control characters")
+    return normalized
+
+
+def _require_safe_uri(value: str, field_name: str) -> str:
+    """Validate a URI without accepting embedded credentials."""
+    normalized = value.strip()
+    if not normalized or len(normalized) > _MAX_URI_LENGTH:
+        raise ValueError(f"{field_name} must be between 1 and {_MAX_URI_LENGTH} characters")
+
+    parsed = urlsplit(normalized)
+    if not parsed.scheme:
+        raise ValueError(f"{field_name} must be an absolute URI")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"{field_name} must not contain credentials")
+    return normalized
 
 
 class InvalidWorkRunTransition(ValueError):

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -1,5 +1,6 @@
 """Framework-independent domain model for governed work execution."""
 
+from dataclasses import dataclass
 from enum import StrEnum
 from urllib.parse import urlsplit
 
@@ -32,6 +33,20 @@ def _require_safe_uri(value: str, field_name: str) -> str:
     if parsed.username is not None or parsed.password is not None:
         raise ValueError(f"{field_name} must not contain credentials")
     return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactReference:
+    """Stable pointer to an artifact produced or consumed by a WorkRun."""
+
+    artifact_id: str
+    kind: str
+    uri: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "artifact_id", _require_bounded_text(self.artifact_id, "artifact_id"))
+        object.__setattr__(self, "kind", _require_bounded_text(self.kind, "kind"))
+        object.__setattr__(self, "uri", _require_safe_uri(self.uri, "uri"))
 
 
 class InvalidWorkRunTransition(ValueError):

--- a/gearmeshing_ai/domain/work_run.py
+++ b/gearmeshing_ai/domain/work_run.py
@@ -80,6 +80,36 @@ class EventReference:
         object.__setattr__(self, "event_type", _require_bounded_text(self.event_type, "event_type"))
 
 
+@dataclass(frozen=True, slots=True)
+class WorkRunCorrelation:
+    """Identifiers used to correlate a WorkRun across governed systems."""
+
+    jira_issue_key: str
+    repository: str
+    branch: str
+    agent_assembly_correlation_id: str
+    pull_request_url: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "jira_issue_key", _require_jira_issue_key(self.jira_issue_key))
+        object.__setattr__(self, "repository", _require_https_url(self.repository, "repository"))
+        object.__setattr__(self, "branch", _require_bounded_text(self.branch, "branch"))
+        object.__setattr__(
+            self,
+            "agent_assembly_correlation_id",
+            _require_bounded_text(
+                self.agent_assembly_correlation_id,
+                "agent_assembly_correlation_id",
+            ),
+        )
+        if self.pull_request_url is not None:
+            object.__setattr__(
+                self,
+                "pull_request_url",
+                _require_https_url(self.pull_request_url, "pull_request_url"),
+            )
+
+
 class InvalidWorkRunTransition(ValueError):
     """Raised when a WorkRun lifecycle transition violates domain rules."""
 

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -5,8 +5,10 @@ from gearmeshing_ai.application.workflow_runner import (
     StageContext,
     WorkflowActions,
     WorkflowCheckpoint,
+    WorkflowFailureKind,
     WorkflowRunner,
     WorkflowStage,
+    WorkflowStageError,
 )
 from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation, WorkRunState
 
@@ -53,3 +55,36 @@ def test_runner_completes_the_mocked_golden_path_in_order() -> None:
         == "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
     )
     assert result.failure is None
+
+
+def test_failed_stage_records_classification_and_stops_advancement() -> None:
+    observed_stages: list[WorkflowStage] = []
+
+    def fail_verification(work_run: WorkRun, context: StageContext) -> WorkRun:
+        observed_stages.append(context.stage)
+        if context.stage is WorkflowStage.VERIFY:
+            raise WorkflowStageError(WorkflowFailureKind.POLICY, "approval_missing")
+        return work_run
+
+    actions = WorkflowActions(
+        ingest=fail_verification,
+        execute=fail_verification,
+        verify=fail_verification,
+        remediate=fail_verification,
+        publish=fail_verification,
+        finish=fail_verification,
+    )
+
+    result = WorkflowRunner(actions).run(WorkflowCheckpoint(work_run=make_work_run()))
+
+    assert observed_stages == [
+        WorkflowStage.INGEST,
+        WorkflowStage.EXECUTE,
+        WorkflowStage.VERIFY,
+    ]
+    assert result.completed_stages == (WorkflowStage.INGEST, WorkflowStage.EXECUTE)
+    assert result.work_run.state is WorkRunState.FAILED
+    assert result.failure is not None
+    assert result.failure.stage is WorkflowStage.VERIFY
+    assert result.failure.kind is WorkflowFailureKind.POLICY
+    assert result.failure.reason_code == "approval_missing"

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -1,0 +1,15 @@
+"""Unit tests for the lightweight workflow runner."""
+
+from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation
+
+
+def make_work_run() -> WorkRun:
+    """Build an approved WorkRun for application runner tests."""
+    return WorkRun(
+        correlation=WorkRunCorrelation(
+            jira_issue_key="GMAI-13",
+            repository="https://github.com/Chisanan232/GearMeshing-AI",
+            branch="mvp1/GMAI-13/poc_workflow_runner",
+            agent_assembly_correlation_id="assembly-run-13",
+        )
+    )

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -7,6 +7,7 @@ import pytest
 from gearmeshing_ai.application.workflow_runner import (
     WORKFLOW_STAGE_ORDER,
     StageContext,
+    StageFailure,
     WorkflowActions,
     WorkflowCheckpoint,
     WorkflowFailureKind,
@@ -59,6 +60,36 @@ def test_checkpoint_enforces_workrun_state_for_every_completed_prefix() -> None:
                 work_run=replace(work_run, state=invalid_state),
                 completed_stages=completed_stages,
             )
+
+
+def test_failed_checkpoint_enforces_stage_and_terminal_state() -> None:
+    completed_stages = (WorkflowStage.INGEST, WorkflowStage.EXECUTE)
+    failed_work_run = replace(make_work_run(), state=WorkRunState.FAILED)
+    failure = StageFailure(
+        stage=WorkflowStage.VERIFY,
+        kind=WorkflowFailureKind.POLICY,
+        reason_code="approval_missing",
+    )
+
+    checkpoint = WorkflowCheckpoint(
+        work_run=failed_work_run,
+        completed_stages=completed_stages,
+        failure=failure,
+    )
+
+    assert checkpoint.failure is failure
+    with pytest.raises(ValueError, match="immediately follow"):
+        WorkflowCheckpoint(
+            work_run=failed_work_run,
+            completed_stages=completed_stages,
+            failure=replace(failure, stage=WorkflowStage.REMEDIATE),
+        )
+    with pytest.raises(ValueError, match="invalid terminal"):
+        WorkflowCheckpoint(
+            work_run=replace(failed_work_run, state=WorkRunState.BLOCKED),
+            completed_stages=completed_stages,
+            failure=failure,
+        )
 
 
 def test_runner_completes_the_mocked_golden_path_in_order() -> None:

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -31,9 +31,7 @@ def test_runner_completes_the_mocked_golden_path_in_order() -> None:
     def record_stage(work_run: WorkRun, context: StageContext) -> WorkRun:
         observed_stages.append(context.stage)
         if context.stage is WorkflowStage.PUBLISH:
-            return work_run.associate_pull_request(
-                "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
-            )
+            return work_run.associate_pull_request("https://github.com/Chisanan232/GearMeshing-AI/pull/13")
         return work_run
 
     actions = WorkflowActions(
@@ -50,10 +48,7 @@ def test_runner_completes_the_mocked_golden_path_in_order() -> None:
     assert tuple(observed_stages) == WORKFLOW_STAGE_ORDER
     assert result.completed_stages == WORKFLOW_STAGE_ORDER
     assert result.work_run.state is WorkRunState.COMPLETED
-    assert (
-        result.work_run.correlation.pull_request_url
-        == "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
-    )
+    assert result.work_run.correlation.pull_request_url == "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
     assert result.failure is None
 
 

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -116,3 +116,28 @@ def test_rerunning_a_completed_stage_skips_its_side_effect() -> None:
     assert call_count == 1
     assert replayed is completed
     assert replayed.completed_stages == (WorkflowStage.INGEST,)
+
+
+def test_unexpected_failure_does_not_expose_exception_details() -> None:
+    def expose_secret(work_run: WorkRun, context: StageContext) -> WorkRun:
+        if context.stage is WorkflowStage.INGEST:
+            sensitive_message = "token=do-not-record"
+            raise RuntimeError(sensitive_message)
+        return work_run
+
+    actions = WorkflowActions(
+        ingest=expose_secret,
+        execute=expose_secret,
+        verify=expose_secret,
+        remediate=expose_secret,
+        publish=expose_secret,
+        finish=expose_secret,
+    )
+
+    result = WorkflowRunner(actions).run(WorkflowCheckpoint(work_run=make_work_run()))
+
+    assert result.work_run.state is WorkRunState.BLOCKED
+    assert result.failure is not None
+    assert result.failure.kind is WorkflowFailureKind.INTERNAL
+    assert result.failure.reason_code == "unexpected_error"
+    assert "do-not-record" not in repr(result)

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -88,3 +88,31 @@ def test_failed_stage_records_classification_and_stops_advancement() -> None:
     assert result.failure.stage is WorkflowStage.VERIFY
     assert result.failure.kind is WorkflowFailureKind.POLICY
     assert result.failure.reason_code == "approval_missing"
+
+
+def test_rerunning_a_completed_stage_skips_its_side_effect() -> None:
+    call_count = 0
+
+    def count_call(work_run: WorkRun, context: StageContext) -> WorkRun:
+        nonlocal call_count
+        del context
+        call_count += 1
+        return work_run
+
+    actions = WorkflowActions(
+        ingest=count_call,
+        execute=count_call,
+        verify=count_call,
+        remediate=count_call,
+        publish=count_call,
+        finish=count_call,
+    )
+    runner = WorkflowRunner(actions)
+    initial = WorkflowCheckpoint(work_run=make_work_run())
+
+    completed = runner.run_stage(initial, WorkflowStage.INGEST)
+    replayed = runner.run_stage(completed, WorkflowStage.INGEST)
+
+    assert call_count == 1
+    assert replayed is completed
+    assert replayed.completed_stages == (WorkflowStage.INGEST,)

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -1,5 +1,9 @@
 """Unit tests for the lightweight workflow runner."""
 
+from dataclasses import replace
+
+import pytest
+
 from gearmeshing_ai.application.workflow_runner import (
     WORKFLOW_STAGE_ORDER,
     StageContext,
@@ -23,6 +27,38 @@ def make_work_run() -> WorkRun:
             agent_assembly_correlation_id="assembly-run-13",
         )
     )
+
+
+def test_checkpoint_enforces_workrun_state_for_every_completed_prefix() -> None:
+    states_after_prefix = (
+        WorkRunState.APPROVED,
+        WorkRunState.EXECUTING,
+        WorkRunState.VERIFYING,
+        WorkRunState.REMEDIATING,
+        WorkRunState.VERIFYING,
+        WorkRunState.PUBLISHING_DRAFT_PR,
+        WorkRunState.COMPLETED,
+    )
+
+    for prefix_length, expected_state in enumerate(states_after_prefix):
+        work_run = make_work_run()
+        if expected_state is WorkRunState.COMPLETED:
+            work_run = work_run.associate_pull_request("https://github.com/Chisanan232/GearMeshing-AI/pull/13")
+        work_run = replace(work_run, state=expected_state)
+        completed_stages = WORKFLOW_STAGE_ORDER[:prefix_length]
+
+        checkpoint = WorkflowCheckpoint(
+            work_run=work_run,
+            completed_stages=completed_stages,
+        )
+
+        assert checkpoint.work_run.state is expected_state
+        invalid_state = WorkRunState.EXECUTING if expected_state is WorkRunState.APPROVED else WorkRunState.APPROVED
+        with pytest.raises(ValueError, match="does not match"):
+            WorkflowCheckpoint(
+                work_run=replace(work_run, state=invalid_state),
+                completed_stages=completed_stages,
+            )
 
 
 def test_runner_completes_the_mocked_golden_path_in_order() -> None:

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -15,7 +15,13 @@ from gearmeshing_ai.application.workflow_runner import (
     WorkflowStage,
     WorkflowStageError,
 )
-from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation, WorkRunState
+from gearmeshing_ai.domain.work_run import (
+    ArtifactReference,
+    EventReference,
+    WorkRun,
+    WorkRunCorrelation,
+    WorkRunState,
+)
 
 
 def make_work_run() -> WorkRun:
@@ -271,3 +277,51 @@ def test_draft_pr_association_is_publish_only_and_write_once() -> None:
     assert overwrite_result.work_run.correlation.pull_request_url == first_pr
     assert overwrite_result.failure is not None
     assert overwrite_result.failure.stage is WorkflowStage.PUBLISH
+
+
+def test_stage_action_cannot_remove_or_replace_existing_evidence() -> None:
+    artifact = ArtifactReference(
+        artifact_id="specification",
+        kind="jira-specification",
+        uri="artifact://specifications/GMAI-13",
+    )
+    event = EventReference(event_id="approved-13", event_type="work.approved")
+    work_run = make_work_run().with_artifact_reference(artifact).with_event_reference(event)
+
+    def remove_artifact(work_run: WorkRun, context: StageContext) -> WorkRun:
+        del context
+        return replace(work_run, artifact_references=())
+
+    remove_actions = WorkflowActions(
+        ingest=remove_artifact,
+        execute=remove_artifact,
+        verify=remove_artifact,
+        remediate=remove_artifact,
+        publish=remove_artifact,
+        finish=remove_artifact,
+    )
+
+    removed_result = WorkflowRunner(remove_actions).run(WorkflowCheckpoint(work_run=work_run))
+
+    assert removed_result.failure is not None
+    assert removed_result.work_run.artifact_references == (artifact,)
+
+    replacement_event = EventReference(event_id="replacement-13", event_type="work.replaced")
+
+    def replace_event(work_run: WorkRun, context: StageContext) -> WorkRun:
+        del context
+        return replace(work_run, event_references=(replacement_event,))
+
+    replace_actions = WorkflowActions(
+        ingest=replace_event,
+        execute=replace_event,
+        verify=replace_event,
+        remediate=replace_event,
+        publish=replace_event,
+        finish=replace_event,
+    )
+
+    replaced_result = WorkflowRunner(replace_actions).run(WorkflowCheckpoint(work_run=work_run))
+
+    assert replaced_result.failure is not None
+    assert replaced_result.work_run.event_references == (event,)

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -1,6 +1,14 @@
 """Unit tests for the lightweight workflow runner."""
 
-from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation
+from gearmeshing_ai.application.workflow_runner import (
+    WORKFLOW_STAGE_ORDER,
+    StageContext,
+    WorkflowActions,
+    WorkflowCheckpoint,
+    WorkflowRunner,
+    WorkflowStage,
+)
+from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation, WorkRunState
 
 
 def make_work_run() -> WorkRun:
@@ -13,3 +21,35 @@ def make_work_run() -> WorkRun:
             agent_assembly_correlation_id="assembly-run-13",
         )
     )
+
+
+def test_runner_completes_the_mocked_golden_path_in_order() -> None:
+    observed_stages: list[WorkflowStage] = []
+
+    def record_stage(work_run: WorkRun, context: StageContext) -> WorkRun:
+        observed_stages.append(context.stage)
+        if context.stage is WorkflowStage.PUBLISH:
+            return work_run.associate_pull_request(
+                "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
+            )
+        return work_run
+
+    actions = WorkflowActions(
+        ingest=record_stage,
+        execute=record_stage,
+        verify=record_stage,
+        remediate=record_stage,
+        publish=record_stage,
+        finish=record_stage,
+    )
+
+    result = WorkflowRunner(actions).run(WorkflowCheckpoint(work_run=make_work_run()))
+
+    assert tuple(observed_stages) == WORKFLOW_STAGE_ORDER
+    assert result.completed_stages == WORKFLOW_STAGE_ORDER
+    assert result.work_run.state is WorkRunState.COMPLETED
+    assert (
+        result.work_run.correlation.pull_request_url
+        == "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
+    )
+    assert result.failure is None

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -203,3 +203,26 @@ def test_unexpected_failure_does_not_expose_exception_details() -> None:
     assert result.failure.kind is WorkflowFailureKind.INTERNAL
     assert result.failure.reason_code == "unexpected_error"
     assert "do-not-record" not in repr(result)
+
+
+def test_stage_action_cannot_change_stable_correlation() -> None:
+    def alter_branch(work_run: WorkRun, context: StageContext) -> WorkRun:
+        del context
+        correlation = replace(work_run.correlation, branch="unauthorized/branch")
+        return replace(work_run, correlation=correlation)
+
+    actions = WorkflowActions(
+        ingest=alter_branch,
+        execute=alter_branch,
+        verify=alter_branch,
+        remediate=alter_branch,
+        publish=alter_branch,
+        finish=alter_branch,
+    )
+
+    result = WorkflowRunner(actions).run(WorkflowCheckpoint(work_run=make_work_run()))
+
+    assert result.completed_stages == ()
+    assert result.work_run.state is WorkRunState.BLOCKED
+    assert result.failure is not None
+    assert result.failure.kind is WorkflowFailureKind.INTERNAL

--- a/test/unit_test/application/test_workflow_runner.py
+++ b/test/unit_test/application/test_workflow_runner.py
@@ -226,3 +226,48 @@ def test_stage_action_cannot_change_stable_correlation() -> None:
     assert result.work_run.state is WorkRunState.BLOCKED
     assert result.failure is not None
     assert result.failure.kind is WorkflowFailureKind.INTERNAL
+
+
+def test_draft_pr_association_is_publish_only_and_write_once() -> None:
+    first_pr = "https://github.com/Chisanan232/GearMeshing-AI/pull/13"
+    replacement_pr = "https://github.com/Chisanan232/GearMeshing-AI/pull/99"
+
+    def associate_early(work_run: WorkRun, context: StageContext) -> WorkRun:
+        del context
+        return work_run.associate_pull_request(first_pr)
+
+    early_actions = WorkflowActions(
+        ingest=associate_early,
+        execute=associate_early,
+        verify=associate_early,
+        remediate=associate_early,
+        publish=associate_early,
+        finish=associate_early,
+    )
+
+    early_result = WorkflowRunner(early_actions).run(WorkflowCheckpoint(work_run=make_work_run()))
+
+    assert early_result.completed_stages == ()
+    assert early_result.failure is not None
+
+    def overwrite_at_publish(work_run: WorkRun, context: StageContext) -> WorkRun:
+        if context.stage is WorkflowStage.PUBLISH:
+            return work_run.associate_pull_request(replacement_pr)
+        return work_run
+
+    overwrite_actions = WorkflowActions(
+        ingest=overwrite_at_publish,
+        execute=overwrite_at_publish,
+        verify=overwrite_at_publish,
+        remediate=overwrite_at_publish,
+        publish=overwrite_at_publish,
+        finish=overwrite_at_publish,
+    )
+    existing_pr_run = make_work_run().associate_pull_request(first_pr)
+
+    overwrite_result = WorkflowRunner(overwrite_actions).run(WorkflowCheckpoint(work_run=existing_pr_run))
+
+    assert overwrite_result.completed_stages == WORKFLOW_STAGE_ORDER[:4]
+    assert overwrite_result.work_run.correlation.pull_request_url == first_pr
+    assert overwrite_result.failure is not None
+    assert overwrite_result.failure.stage is WorkflowStage.PUBLISH

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -82,3 +82,30 @@ def test_work_run_rejects_invalid_transitions(
 
     with pytest.raises(InvalidWorkRunTransition, match=f"cannot transition from {source} to {target}"):
         work_run.transition_to(target)
+
+
+@pytest.mark.parametrize(
+    ("source", "outcome"),
+    [
+        (WorkRunState.PUBLISHING_DRAFT_PR, WorkRunState.COMPLETED),
+        (WorkRunState.EXECUTING, WorkRunState.FAILED),
+        (WorkRunState.EXECUTING, WorkRunState.BLOCKED),
+        (WorkRunState.EXECUTING, WorkRunState.CANCELLED),
+    ],
+)
+def test_work_run_supports_terminal_outcomes(
+    source: WorkRunState,
+    outcome: WorkRunState,
+) -> None:
+    work_run = WorkRun(
+        correlation=make_work_run(
+            pull_request_url="https://github.com/Chisanan232/GearMeshing-AI/pull/42"
+        ).correlation,
+        state=source,
+    )
+
+    terminal_work_run = work_run.transition_to(outcome)
+
+    assert terminal_work_run.state.is_terminal
+    with pytest.raises(InvalidWorkRunTransition):
+        terminal_work_run.transition_to(WorkRunState.EXECUTING)

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -1,0 +1,16 @@
+"""Unit tests for the WorkRun domain model."""
+
+from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation
+
+
+def make_work_run(*, pull_request_url: str | None = None) -> WorkRun:
+    """Build a valid WorkRun for focused lifecycle tests."""
+    return WorkRun(
+        correlation=WorkRunCorrelation(
+            jira_issue_key="GMAI-11",
+            repository="https://github.com/Chisanan232/GearMeshing-AI",
+            branch="mvp1/GMAI-11/workrun_state_model",
+            agent_assembly_correlation_id="assembly-run-42",
+            pull_request_url=pull_request_url,
+        )
+    )

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -109,3 +109,13 @@ def test_work_run_supports_terminal_outcomes(
     assert terminal_work_run.state.is_terminal
     with pytest.raises(InvalidWorkRunTransition):
         terminal_work_run.transition_to(WorkRunState.EXECUTING)
+
+
+def test_work_run_requires_draft_pr_before_completion() -> None:
+    work_run = WorkRun(
+        correlation=make_work_run().correlation,
+        state=WorkRunState.PUBLISHING_DRAFT_PR,
+    )
+
+    with pytest.raises(InvalidWorkRunTransition, match="must reference its Draft PR"):
+        work_run.transition_to(WorkRunState.COMPLETED)

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -6,6 +6,7 @@ import pytest
 
 from gearmeshing_ai.domain.work_run import (
     ArtifactReference,
+    EventReference,
     InvalidWorkRunTransition,
     WorkRun,
     WorkRunCorrelation,
@@ -146,3 +147,17 @@ def test_work_run_attaches_artifact_references_idempotently() -> None:
     assert with_artifact.artifact_references == (artifact,)
     assert with_artifact.with_artifact_reference(artifact) is with_artifact
     assert work_run.artifact_references == ()
+
+
+def test_work_run_attaches_event_references_idempotently() -> None:
+    work_run = make_work_run()
+    event = EventReference(
+        event_id="event-42",
+        event_type="verification.completed",
+    )
+
+    with_event = work_run.with_event_reference(event)
+
+    assert with_event.event_references == (event,)
+    assert with_event.with_event_reference(event) is with_event
+    assert work_run.event_references == ()

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -196,3 +196,17 @@ def test_work_run_correlation_rejects_invalid_identifiers() -> None:
             branch="unsafe branch",
             agent_assembly_correlation_id="assembly-run-42",
         )
+
+
+def test_work_run_rejects_invalid_reference_collections() -> None:
+    with pytest.raises(TypeError, match="ArtifactReference"):
+        WorkRun(
+            correlation=make_work_run().correlation,
+            artifact_references=("not-an-artifact",),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(TypeError, match="EventReference"):
+        WorkRun(
+            correlation=make_work_run().correlation,
+            event_references=("not-an-event",),  # type: ignore[arg-type]
+        )

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -161,3 +161,20 @@ def test_work_run_attaches_event_references_idempotently() -> None:
     assert with_event.event_references == (event,)
     assert with_event.with_event_reference(event) is with_event
     assert work_run.event_references == ()
+
+
+def test_work_run_references_reject_embedded_credentials() -> None:
+    with pytest.raises(ValueError, match="must not contain credentials"):
+        WorkRunCorrelation(
+            jira_issue_key="GMAI-11",
+            repository="https://token@example.com/repository",
+            branch="feature/safe-branch",
+            agent_assembly_correlation_id="assembly-run-42",
+        )
+
+    with pytest.raises(ValueError, match="must not contain credentials"):
+        ArtifactReference(
+            artifact_id="verification-report",
+            kind="test-report",
+            uri="https://token@example.com/report.json",
+        )

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -7,7 +7,7 @@ import pytest
 from gearmeshing_ai.domain.work_run import (
     ArtifactReference,
     EventReference,
-    InvalidWorkRunTransition,
+    InvalidWorkRunTransitionError,
     WorkRun,
     WorkRunCorrelation,
     WorkRunState,
@@ -82,7 +82,7 @@ def test_work_run_rejects_invalid_transitions(
 ) -> None:
     work_run = WorkRun(correlation=make_work_run().correlation, state=source)
 
-    with pytest.raises(InvalidWorkRunTransition, match=f"cannot transition from {source} to {target}"):
+    with pytest.raises(InvalidWorkRunTransitionError, match=f"cannot transition from {source} to {target}"):
         work_run.transition_to(target)
 
 
@@ -109,7 +109,7 @@ def test_work_run_supports_terminal_outcomes(
     terminal_work_run = work_run.transition_to(outcome)
 
     assert terminal_work_run.state.is_terminal
-    with pytest.raises(InvalidWorkRunTransition):
+    with pytest.raises(InvalidWorkRunTransitionError):
         terminal_work_run.transition_to(WorkRunState.EXECUTING)
 
 
@@ -119,7 +119,7 @@ def test_work_run_requires_draft_pr_before_completion() -> None:
         state=WorkRunState.PUBLISHING_DRAFT_PR,
     )
 
-    with pytest.raises(InvalidWorkRunTransition, match="must reference its Draft PR"):
+    with pytest.raises(InvalidWorkRunTransitionError, match="must reference its Draft PR"):
         work_run.transition_to(WorkRunState.COMPLETED)
 
 

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -2,6 +2,8 @@
 
 from uuid import UUID
 
+import pytest
+
 from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation, WorkRunState
 
 
@@ -27,3 +29,33 @@ def test_work_run_starts_approved_with_cross_system_correlation() -> None:
     assert work_run.correlation.repository == "https://github.com/Chisanan232/GearMeshing-AI"
     assert work_run.correlation.branch == "mvp1/GMAI-11/workrun_state_model"
     assert work_run.correlation.agent_assembly_correlation_id == "assembly-run-42"
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        (WorkRunState.APPROVED, WorkRunState.EXECUTING),
+        (WorkRunState.EXECUTING, WorkRunState.VERIFYING),
+        (WorkRunState.VERIFYING, WorkRunState.REMEDIATING),
+        (WorkRunState.REMEDIATING, WorkRunState.EXECUTING),
+        (WorkRunState.REMEDIATING, WorkRunState.VERIFYING),
+        (WorkRunState.VERIFYING, WorkRunState.PUBLISHING_DRAFT_PR),
+        (WorkRunState.PUBLISHING_DRAFT_PR, WorkRunState.COMPLETED),
+    ],
+)
+def test_work_run_accepts_happy_path_and_remediation_transitions(
+    source: WorkRunState,
+    target: WorkRunState,
+) -> None:
+    work_run = WorkRun(
+        correlation=make_work_run(
+            pull_request_url="https://github.com/Chisanan232/GearMeshing-AI/pull/42"
+        ).correlation,
+        state=source,
+    )
+
+    transitioned = work_run.transition_to(target)
+
+    assert transitioned.state is target
+    assert transitioned.identity == work_run.identity
+    assert work_run.state is source

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -55,9 +55,7 @@ def test_work_run_accepts_happy_path_and_remediation_transitions(
     target: WorkRunState,
 ) -> None:
     work_run = WorkRun(
-        correlation=make_work_run(
-            pull_request_url="https://github.com/Chisanan232/GearMeshing-AI/pull/42"
-        ).correlation,
+        correlation=make_work_run(pull_request_url="https://github.com/Chisanan232/GearMeshing-AI/pull/42").correlation,
         state=source,
     )
 
@@ -100,9 +98,7 @@ def test_work_run_supports_terminal_outcomes(
     outcome: WorkRunState,
 ) -> None:
     work_run = WorkRun(
-        correlation=make_work_run(
-            pull_request_url="https://github.com/Chisanan232/GearMeshing-AI/pull/42"
-        ).correlation,
+        correlation=make_work_run(pull_request_url="https://github.com/Chisanan232/GearMeshing-AI/pull/42").correlation,
         state=source,
     )
 

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import pytest
 
 from gearmeshing_ai.domain.work_run import (
+    ArtifactReference,
     InvalidWorkRunTransition,
     WorkRun,
     WorkRunCorrelation,
@@ -130,3 +131,18 @@ def test_work_run_associates_a_draft_pr_without_mutation() -> None:
     assert correlated.correlation.pull_request_url == pull_request_url
     assert correlated.identity == work_run.identity
     assert work_run.correlation.pull_request_url is None
+
+
+def test_work_run_attaches_artifact_references_idempotently() -> None:
+    work_run = make_work_run()
+    artifact = ArtifactReference(
+        artifact_id="verification-report",
+        kind="test-report",
+        uri="artifact://reports/verification.json",
+    )
+
+    with_artifact = work_run.with_artifact_reference(artifact)
+
+    assert with_artifact.artifact_references == (artifact,)
+    assert with_artifact.with_artifact_reference(artifact) is with_artifact
+    assert work_run.artifact_references == ()

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -1,6 +1,8 @@
 """Unit tests for the WorkRun domain model."""
 
-from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation
+from uuid import UUID
+
+from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation, WorkRunState
 
 
 def make_work_run(*, pull_request_url: str | None = None) -> WorkRun:
@@ -14,3 +16,14 @@ def make_work_run(*, pull_request_url: str | None = None) -> WorkRun:
             pull_request_url=pull_request_url,
         )
     )
+
+
+def test_work_run_starts_approved_with_cross_system_correlation() -> None:
+    work_run = make_work_run()
+
+    assert isinstance(work_run.identity.run_id, UUID)
+    assert work_run.state is WorkRunState.APPROVED
+    assert work_run.correlation.jira_issue_key == "GMAI-11"
+    assert work_run.correlation.repository == "https://github.com/Chisanan232/GearMeshing-AI"
+    assert work_run.correlation.branch == "mvp1/GMAI-11/workrun_state_model"
+    assert work_run.correlation.agent_assembly_correlation_id == "assembly-run-42"

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -4,7 +4,12 @@ from uuid import UUID
 
 import pytest
 
-from gearmeshing_ai.domain.work_run import WorkRun, WorkRunCorrelation, WorkRunState
+from gearmeshing_ai.domain.work_run import (
+    InvalidWorkRunTransition,
+    WorkRun,
+    WorkRunCorrelation,
+    WorkRunState,
+)
 
 
 def make_work_run(*, pull_request_url: str | None = None) -> WorkRun:
@@ -59,3 +64,21 @@ def test_work_run_accepts_happy_path_and_remediation_transitions(
     assert transitioned.state is target
     assert transitioned.identity == work_run.identity
     assert work_run.state is source
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        (WorkRunState.APPROVED, WorkRunState.VERIFYING),
+        (WorkRunState.EXECUTING, WorkRunState.COMPLETED),
+        (WorkRunState.VERIFYING, WorkRunState.VERIFYING),
+    ],
+)
+def test_work_run_rejects_invalid_transitions(
+    source: WorkRunState,
+    target: WorkRunState,
+) -> None:
+    work_run = WorkRun(correlation=make_work_run().correlation, state=source)
+
+    with pytest.raises(InvalidWorkRunTransition, match=f"cannot transition from {source} to {target}"):
+        work_run.transition_to(target)

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -119,3 +119,14 @@ def test_work_run_requires_draft_pr_before_completion() -> None:
 
     with pytest.raises(InvalidWorkRunTransition, match="must reference its Draft PR"):
         work_run.transition_to(WorkRunState.COMPLETED)
+
+
+def test_work_run_associates_a_draft_pr_without_mutation() -> None:
+    work_run = make_work_run()
+    pull_request_url = "https://github.com/Chisanan232/GearMeshing-AI/pull/42"
+
+    correlated = work_run.associate_pull_request(pull_request_url)
+
+    assert correlated.correlation.pull_request_url == pull_request_url
+    assert correlated.identity == work_run.identity
+    assert work_run.correlation.pull_request_url is None

--- a/test/unit_test/domain/test_work_run.py
+++ b/test/unit_test/domain/test_work_run.py
@@ -178,3 +178,21 @@ def test_work_run_references_reject_embedded_credentials() -> None:
             kind="test-report",
             uri="https://token@example.com/report.json",
         )
+
+
+def test_work_run_correlation_rejects_invalid_identifiers() -> None:
+    with pytest.raises(ValueError, match="PROJECT-123"):
+        WorkRunCorrelation(
+            jira_issue_key="not-a-key",
+            repository="https://github.com/example/repository",
+            branch="feature/safe-branch",
+            agent_assembly_correlation_id="assembly-run-42",
+        )
+
+    with pytest.raises(ValueError, match="must not contain whitespace"):
+        WorkRunCorrelation(
+            jira_issue_key="GMAI-11",
+            repository="https://github.com/example/repository",
+            branch="unsafe branch",
+            agent_assembly_correlation_id="assembly-run-42",
+        )


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Implement the deterministic MVP 1 POC workflow runner with replay-safe stage boundaries and terminal failure handling.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: GMAI-13.
    * Relative task IDs:
        * [x] GMAI-11.
    * Relative PRs:
        * Depends on #48. This PR is intentionally stacked on the GMAI-11 WorkRun model and must not merge before #48.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * Runs ingest, execute, verify, remediate, publish, and finish in a fixed sequence.
    * Advances lifecycle state only through the WorkRun domain contract.
    * Returns immutable checkpoints that skip completed stages on replay.
    * Rejects persisted checkpoints whose stage prefix, WorkRun state, or terminal failure metadata disagree before callbacks run.
    * Preserves stable correlation, write-once Draft PR association, and monotonic artifact/event evidence across adapter boundaries.
    * Records bounded classified failures without exposing exception details.

[//]: # (What scope in project it would affect with your modify?)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] 👮🏻‍♂️ Abstraction or base objects
        * [ ] 🤖 AI agent
        * [ ] 📲 Info Provider
        * [ ] 🕸️ Web server
        * [ ] 📲 MCP client
        * [ ] 🪡 API client
        * [x] 🫀 Data model
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
        * [ ] 🧪 Smoke testing (with AI models real calling)
        * [ ] 🧪 Contract testing
        * [ ] 🧪 Evaluation testing
    * [ ] 📚 Documentation
    * [ ] 🚀 Building
* Additional description:
    Framework-neutral synchronous action protocols keep the domain contract adaptable to a later LangGraph wrapper without taking a LangGraph dependency here.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Added explicit stage action, context, checkpoint, and classified error contracts.
* Added deterministic sequential execution and stage replay protection.
* Added focused tests for the golden path, terminal failure behavior, idempotency, and failure redaction.
* Verification: 31 focused domain/application tests passed; Ruff and strict mypy passed.
* Repository-wide pytest was stopped after 135 seconds at an existing MCP end-to-end test waiting on an unavailable external service; 36 tests had passed and 30 credential-gated smoke tests had skipped before interruption.